### PR TITLE
Add build def and form option for EPS 101

### DIFF
--- a/build/eps101.def
+++ b/build/eps101.def
@@ -1,0 +1,9 @@
+Bootstrap: docker
+Registry: quay.io
+From: jupyter/scipy-notebook:lab-4.2.4
+
+%post
+pip3 install \
+    cartopy \
+    gsw \
+    netCDF4

--- a/form.yml
+++ b/form.yml
@@ -16,6 +16,7 @@ attributes:
       - ["ECON 1123", "general-econ-rstudio.sif"]
       - ["ECON 2110", "econ2110.sif"]
       - ["ECON 50A", "general-econ-rstudio.sif"]
+      - ["E-PSCI 101", eps101.sif]
       - ["Torch", "jupyter-torch.sif"]
       - ["datascience-notebook", "datascience-notebook.sif"]
     help:


### PR DESCRIPTION
# Overview

In order to more quickly address the issue with PDF creation that EPS 101 users reported, this PR re-creates their environment in the Apptainer implementation, rather than the Spack / Conda implementation. 

The other implementation requires both Python and system packages to work, and installing system packages has proven challenging, so this is a path of lesser resistance.

I tested the image built with this def file in a development app in production, and I was able to run the added packages and then export the notebook to PDF.

# Changes

This adds a build definition for an `eps101` Apptainer image with the addition of `cartopy`, `gsw` and `netCDF4` Python packages. It also adds the resulting image file to the list of options available to the app.

# Notes

Software was tested with the following lines of Python:

## cartopy

Cartopy was tested by going through a few steps of a [cartopy tutorial](https://foundations.projectpythia.org/core/cartopy/cartopy.html) in a Jupyter Notebook. Output in notebook cells matched what was shown in the tutorial.

<details>
  <summary>Show code</summary>

```python
import warnings

import matplotlib.pyplot as plt
import numpy as np

from cartopy import crs as ccrs, feature as cfeature

# --- new cell ---

fig = plt.figure(figsize=(11, 8.5))
ax = plt.subplot(1, 1, 1, projection=ccrs.PlateCarree(central_longitude=-75))
ax.set_title("A Geo-referenced subplot, Plate Carree projection");

# --- new cell ---

ax.coastlines()

# --- new cell ---

fig
```
</details>

## gsw

I was unable to find a tutorial or quickstart for `gsw`, but I verified the import:

```python
import gsw
```

## netCDF4

I took some sample code from a [netCDF4 tutorial](https://github.com/Unidata/netcdf4-python/blob/master/examples/tutorial.py) and verified that it ran.

<details>
  <summary>Show code</summary>

```python
from typing import Literal
from netCDF4 import Dataset

# --- new cell ---

# code from tutorial.

# create a file (Dataset object, also the root group).
rootgrp = Dataset('test.nc', 'w', format='NETCDF4')
print(rootgrp.file_format)
rootgrp.close()

# --- new cell ---

# create some groups.
rootgrp = Dataset('test.nc', 'a')
fcstgrp = rootgrp.createGroup('forecasts')
analgrp = rootgrp.createGroup('analyses')
fcstgrp1 = rootgrp.createGroup('/forecasts/model1')
fcstgrp2 = rootgrp.createGroup('/forecasts/model2')

# --- new cell ---

# walk the group tree using a Python generator.
def walktree(top):
    yield top.groups.values()
    for value in top.groups.values():
        yield from walktree(value)

# --- new cell ---

print(rootgrp)
for children in walktree(rootgrp):
    for child in children:
        print(child)
```

</details>