### PR TITLE
Update - Fall 2025

### DIFF
--- a/build/datascience-notebook.def
+++ b/build/datascience-notebook.def
@@ -1,3 +1,3 @@
 Bootstrap: docker
 Registry: quay.io
-From: jupyter/datascience-notebook:lab-4.2.4
+From: jupyter/datascience-notebook:lab-4.4.5

--- a/build/econ2110.def
+++ b/build/econ2110.def
@@ -1,6 +1,6 @@
 Bootstrap:docker
 Registry: quay.io
-From: jupyter/datascience-notebook:lab-4.2.4
+From: jupyter/datascience-notebook:lab-4.4,5
 
 %post
 cat << EOF > /tmp/requirements.txt

--- a/build/eps101.def
+++ b/build/eps101.def
@@ -1,6 +1,6 @@
 Bootstrap: docker
 Registry: quay.io
-From: jupyter/scipy-notebook:lab-4.2.4
+From: jupyter/scipy-notebook:lab-4.4.5
 
 %post
 pip3 install \

--- a/build/general-econ-rstudio.def
+++ b/build/general-econ-rstudio.def
@@ -1,6 +1,6 @@
 Bootstrap: docker
 Registry: quay.io
-From: jupyter/datascience-notebook:lab-4.2.4
+From: jupyter/datascience-notebook:lab-4.4.5
 
 %post -c /bin/bash
 cat << EOF > /tmp/requirements.txt

--- a/build/jupyter-torch.def
+++ b/build/jupyter-torch.def
@@ -1,6 +1,6 @@
 Bootstrap: docker
 Registry: quay.io
-From: jupyter/scipy-notebook:lab-4.2.4
+From: jupyter/scipy-notebook:lab-4.4.5
 
 %post
 pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu

--- a/build/scipy-notebook.def
+++ b/build/scipy-notebook.def
@@ -1,3 +1,3 @@
 Bootstrap: docker
 Registry: quay.io
-From: jupyter/scipy-notebook:lab-4.2.4
+From: jupyter/scipy-notebook:lab-4.4.5

--- a/form.yml
+++ b/form.yml
@@ -1,34 +1,4 @@
----
-cluster: "*"
-cacheable: false
-form:
-  - bc_num_hours
-  - bc_num_slots
-  - imagefile
-  - custom_num_cores
-attributes:
-  imagefile:
-    display: true
-    widget: "select"
-    label: "Jupyter Lab Container"
-    options:
-      - ["scipy-notebook", "scipy-notebook.sif"]
-      - ["ECON 1123", "general-econ-rstudio.sif"]
-      - ["ECON 2110", "econ2110.sif"]
-      - ["ECON 50A", "general-econ-rstudio.sif"]
-      - ["E-PSCI 101", eps101.sif]
-      - ["Torch", "jupyter-torch.sif"]
-      - ["datascience-notebook", "datascience-notebook.sif"]
-    help:
-      Select an container to use. Different containers are configured with
-      different software. If your instructor hasn't told you to use a specific
-      image, and you don't see your course code in the list, you likely need to
-      use the default `scipy-notebook` container.
-  bc_num_slots: null
-  custom_num_cores:
-    widget: "number_field"
-    label: "Number of CPUs"
-    value: 1
-    min: 1
-    max: 4
-    step: 1
+# This OnDemand app configuration uses sub-apps by default to allow for custom
+# sub-apps. The default configuration is in `local/generic.yml.erb`, which is
+# the file that should be referenced for creating a new sub-app with this
+# configuration.

--- a/local/generic.yml.erb
+++ b/local/generic.yml.erb
@@ -75,7 +75,7 @@ attributes:
   # when starting the app via apptainer. The .sif file must exist at 
   # /shared/apptainerImages. The build definition for any app referenced by a
   # sub-app should be included in the build folder as a .def file.
-  imagefile: "datascience-notebook.sif"
+  imagefile: "scipy-notebook.sif"
 
   # How many CPU cores to include in the slurm job submission
   custom_num_cores:

--- a/local/generic.yml.erb
+++ b/local/generic.yml.erb
@@ -1,0 +1,34 @@
+---
+cluster: "*"
+cacheable: false
+form:
+  - bc_num_hours
+  - bc_num_slots
+  - imagefile
+  - custom_num_cores
+attributes:
+  imagefile:
+    display: true
+    widget: "select"
+    label: "Jupyter Lab Container"
+    options:
+      - ["scipy-notebook", "scipy-notebook.sif"]
+      - ["ECON 1123", "general-econ-rstudio.sif"]
+      - ["ECON 2110", "econ2110.sif"]
+      - ["ECON 50A", "general-econ-rstudio.sif"]
+      - ["E-PSCI 101", eps101.sif]
+      - ["Torch", "jupyter-torch.sif"]
+      - ["datascience-notebook", "datascience-notebook.sif"]
+    help:
+      Select an container to use. Different containers are configured with
+      different software. If your instructor hasn't told you to use a specific
+      image, and you don't see your course code in the list, you likely need to
+      use the default `scipy-notebook` container.
+  bc_num_slots: null
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1

--- a/local/generic.yml.erb
+++ b/local/generic.yml.erb
@@ -1,30 +1,83 @@
+# Jupyter app user-facing configuration form file (default sub-app)
+# This config file is both an actual configuration file for an actual sample 
+# application, and a starting point for configuring a new sub-app. To make a
+# custom application launch for a course, make a copy of this file in the same 
+# folder and customize the form config to your liking. There are notes along
+# the way to help you understand what options you can make configurable to users.
+# See the docs page from Open OnDemand for more details:
+# https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form.html
+<%-
+# Specify admin groups by the full name of the group in the production HKey environment.
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+# Specify course groups by Canvas course ID, which you can find in a url:
+# canvas.harvard.edu/courses/000000
+enabledGroups = [
+  "135510"
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
 ---
-cluster: "*"
+cluster: "<%= cluster %>"
+title: "Jupyter Lab - Generic (Apptainer)"
 cacheable: false
+
+# Form attributes that will be presented to the user and available to the 
+# scripts that launch the app. Think of this as initializing variables for use 
+# in the attributes section as needed.
 form:
   - bc_num_hours
-  - bc_num_slots
+  - bc_queue
   - imagefile
   - custom_num_cores
+
+# Customize how form variables appear to users. This is also where you can set 
+# a static value for a variable, in which case it will not be visible to users.
 attributes:
-  imagefile:
-    display: true
-    widget: "select"
-    label: "Jupyter Lab Container"
-    options:
-      - ["scipy-notebook", "scipy-notebook.sif"]
-      - ["ECON 1123", "general-econ-rstudio.sif"]
-      - ["ECON 2110", "econ2110.sif"]
-      - ["ECON 50A", "general-econ-rstudio.sif"]
-      - ["E-PSCI 101", eps101.sif]
-      - ["Torch", "jupyter-torch.sif"]
-      - ["datascience-notebook", "datascience-notebook.sif"]
-    help:
-      Select an container to use. Different containers are configured with
-      different software. If your instructor hasn't told you to use a specific
-      image, and you don't see your course code in the list, you likely need to
-      use the default `scipy-notebook` container.
-  bc_num_slots: null
+  # How long will the job run for? Configure min, max, and step to set limits 
+  # on how long app sessions can run.
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 6  # 6 hours max
+    step: 1
+
+  # Which queue to submit to. Usually `general` is the best choice, unless this 
+  # app is configured for a specific EC2 instance type, like an instance type 
+  # with GPU resources.
+  bc_queue: "general"
+
+  # Which Apptainer image file to use. This is used by the script.sh.erb file 
+  # when starting the app via apptainer. The .sif file must exist at 
+  # /shared/apptainerImages. The build definition for any app referenced by a
+  # sub-app should be included in the build folder as a .def file.
+  imagefile: "datascience-notebook.sif"
+
+  # How many CPU cores to include in the slurm job submission
   custom_num_cores:
     widget: "number_field"
     label: "Number of CPUs"

--- a/spack-environment/apptainer/spack.yml
+++ b/spack-environment/apptainer/spack.yml
@@ -5,7 +5,7 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - apptainer@1.3.1
+  - apptainer@1.4.1
   view: true
   concretizer:
     unify: true

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,7 +1,6 @@
 ---
 batch_connect:
   template: "basic"
-  set_host: "host=$(hostname | awk '{print $1}').<%= cluster%>.pcluster"
 script:
   native:
     - "--nodes=1"

--- a/template/after.sh
+++ b/template/after.sh
@@ -1,12 +1,20 @@
+#!/usr/bin/env bash
+
+this_script="template/after.sh"
+
+log() {
+    echo -e "[$(date -Iseconds)][${this_script}] $1"
+}
+
 # Wait for the Jupyter Notebook server to start
-echo "Waiting for Jupyter Notebook server to open port ${port}..."
-echo "TIMING - Starting wait at: $(date)"
+log "Waiting for Jupyter Notebook server to open port ${port}..."
+log "Starting wait"
 if wait_until_port_used "${host}:${port}" 600; then
-  echo "Discovered Jupyter Notebook server listening on port ${port}!"
-  echo "TIMING - Wait ended at: $(date)"
+  log "Discovered Jupyter Notebook server listening on port ${port}!"
+  log "Wait ended"
 else
-  echo "Timed out waiting for Jupyter Notebook server to open port ${port}!"
-  echo "TIMING - Wait ended at: $(date)"
+  log "Timed out waiting for Jupyter Notebook server to open port ${port}!"
+  log "Wait ended"
   pkill -P ${SCRIPT_PID}
   clean_up 1
 fi

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -26,6 +26,18 @@
 #   - $password
 #       The plain text password used to authenticate to the web server with
 
+this_script="template/before.sh.erb"
+
+log() {
+    echo -e "[$(date -Iseconds)][${this_script}] $1"
+}
+
+# Validate home directory and set it to what it should be
+log "original HOME=$HOME"
+log "user=$(id -nu)"
+export HOME="/shared/home/$(id -nu)"
+log "new HOME=$HOME"
+
 # Export the module function if it exists
 [[ $(type -t module) == "function" ]] && export -f module
 
@@ -45,15 +57,15 @@ export CONFIG_FILE="${PWD}/config.py"
 (
 umask 077
 cat > "${CONFIG_FILE}" << EOL
-c.NotebookApp.ip = '0.0.0.0'
-c.NotebookApp.port = ${port}
-c.NotebookApp.port_retries = 0
-c.NotebookApp.password = u'sha1:${SALT}:${PASSWORD_SHA1}'
-c.NotebookApp.base_url = '/node/${host}/${port}/'
+c.ServerApp.ip = '0.0.0.0'
+c.ServerApp.port = ${port}
+c.ServerApp.port_retries = 0
+c.PasswordIdentityProvider.hashed_password = u'sha1:${SALT}:${PASSWORD_SHA1}'
+c.ServerApp.base_url = '/node/${host}/${port}/'
 c.NotebookApp.open_browser = False
-c.NotebookApp.allow_origin = '*'
-c.NotebookApp.notebook_dir = '${HOME}'
-c.NotebookApp.disable_check_xsrf = True
+c.ServerApp.allow_origin = '*'
+c.ServerApp.notebook_dir = '${HOME}'
+c.ServerApp.disable_check_xsrf = True
 EOL
 )
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -40,21 +40,21 @@ export APPTAINERENV_APPEND_PATH="/opt/slurm/bin"
 
 ## bind parts of the filesystem to be able to talk to slurm from within the container
 export SING_BINDS=""
-export SING_BINDS="$SING_BINDS -B /shared/courseSharedFolders"
-export SING_BINDS="$SING_BINDS -B /shared/spack"
-export SING_BINDS="$SING_BINDS -B /etc/nsswitch.conf"
-export SING_BINDS="$SING_BINDS -B /etc/sssd/"
-export SING_BINDS="$SING_BINDS -B /var/lib/sss"
-export SING_BINDS="$SING_BINDS -B /opt/slurm"
+# export SING_BINDS="$SING_BINDS -B /shared/courseSharedFolders"
+# export SING_BINDS="$SING_BINDS -B /shared/spack"
+# export SING_BINDS="$SING_BINDS -B /etc/nsswitch.conf"
+# export SING_BINDS="$SING_BINDS -B /etc/sssd/"
+# export SING_BINDS="$SING_BINDS -B /var/lib/sss"
+# export SING_BINDS="$SING_BINDS -B /opt/slurm"
 # export SING_BINDS="$SING_BINDS -B /slurm" # location does not exist, unsure of purpose
-export SING_BINDS="$SING_BINDS -B /var/run/munge"
-export SING_BINDS="$SING_BINDS -B `which sbatch `"
-export SING_BINDS="$SING_BINDS -B `which srun `"
-export SING_BINDS="$SING_BINDS -B `which sacct `"
-export SING_BINDS="$SING_BINDS -B `which scontrol `"
-export SING_BINDS="$SING_BINDS -B `which salloc `"
+# export SING_BINDS="$SING_BINDS -B /var/run/munge"
+# export SING_BINDS="$SING_BINDS -B `which sbatch `"
+# export SING_BINDS="$SING_BINDS -B `which srun `"
+# export SING_BINDS="$SING_BINDS -B `which sacct `"
+# export SING_BINDS="$SING_BINDS -B `which scontrol `"
+# export SING_BINDS="$SING_BINDS -B `which salloc `"
 # export SING_BINDS="$SING_BINDS -B /usr/lib64/slurm/ " # location does not exist, unsure of purpose
-export SING_BINDS="$SING_BINDS -B /usr/lib64/libreadline.so.6" # missing file, causing issues with scontrol
+# export SING_BINDS="$SING_BINDS -B /usr/lib64/libreadline.so.6" # missing file, causing issues with scontrol
 export SING_BINDS="$SING_BINDS -B ${WORKDIR}/tmp:/tmp " ## job specific tmp dir
 log "SING_BINDS=${SING_BINDS}"
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,14 +1,13 @@
  #!/bin/bash
 
-# Benchmark info
-echo "TIMING - Starting main script at: $(date)"
+this_script="template/script.sh.erb"
 
-# Validate home directory and set it to what it should be
-# This hedges against LDAP being unavailable or timing out
-echo "original HOME=$HOME"
-echo "user=$(id -nu)"
-export HOME="/shared/home/$(id -nu)"
-echo "new HOME=$HOME"
+log() {
+    echo -e "[$(date -Iseconds)][${this_script}] $1"
+}
+
+# Benchmark info
+log "Starting main script"
 
 # Set working directory to home directory
 cd "${HOME}"
@@ -57,16 +56,16 @@ export SING_BINDS="$SING_BINDS -B `which salloc `"
 # export SING_BINDS="$SING_BINDS -B /usr/lib64/slurm/ " # location does not exist, unsure of purpose
 export SING_BINDS="$SING_BINDS -B /usr/lib64/libreadline.so.6" # missing file, causing issues with scontrol
 export SING_BINDS="$SING_BINDS -B ${WORKDIR}/tmp:/tmp " ## job specific tmp dir
-echo "SING_BINDS=${SING_BINDS}"
+log "SING_BINDS=${SING_BINDS}"
 
-echo "JOBROOT=${JOBROOT}"
+log "JOBROOT=${JOBROOT}"
 
-echo "TIMING - Starting to load Spack environment: $(date)"
+log "Starting to load Spack environment"
 
 # Load apptainer from spack before running image
 . /shared/spack/share/spack/setup-env.sh
 spack env activate apptainer
 
-echo "TIMING - Starting Jupyter: $(date)"
+log "Starting Jupyter"
 
 apptainer exec $SING_BINDS $container_image $JOBROOT/jupyter.script.sh


### PR DESCRIPTION
# Overview

This PR updates the app configuration to be consistent with other apps, and to be (hopefully) easier to maintain and build off of. This includes improved logging, better code organization, and a more effective separation of concerns between the app and the OOD cluster config.

# Changes

These changes are pretty much the same as the changes in https://github.com/Harvard-ATG/ood-jupyterlab-spack-conda/pull/24 for the spack-conda implementation of Jupyter Lab, so the notes are the same, just reproduced here for ease of reference. There some things that are unique to this PR though:
1. There's no GPU queue settings to update.
2. The Apptainer definitions have had the version of the base container updated
3. This app now uses a sub-app configuration.

## Apptainer image definition base container updates

The base versions for image build definitions have been updated with the latest "lab" tag from their repositories on quay.io.

## Sub-app configuration

This app now uses sub-apps, following the pattern from our other Jupyter implementations. The access restrictions based on group membership from other apps has been reproduced here, and the generic form.yml file in the `local` folder has been updated with more notes on what each thing does.

## Logging

Inspired by Vesna's work on a setup script for the prometheus installer for the slurm rest setup, I've added a `log` function to the scripts in the app. The function logs the time that the line ran, as well as the originating script, so you can tell when a line is coming from `script.sh` vs `before.sh`, etc. It also means that the "TIMING" bits from lines aren't necessary.

## Organization

I've moved the declaration of groups to be given access to the app to the top of the `form.yml`-style file in the `local` directory, to make it easier to find the stuff that's most commonly edited.

I also removed the contents of the `form.yml` file in the root of the directory, since it's not in use and removing its contents doesn't break anything. It just has a pointer to the generic setup file in the `local` directory, which is actually what's in use.

## `set_host`

We've been setting the `set_host` parameter on each app in our cluster to adjust to how Parallel Cluster handles routing interactive apps to compute nodes. That makes our apps less interoperable, since someone reusing our apps would have to remove this parameter. It also introduces room for error in our setup, where we could forget this parameter or set it up incorrectly in a new app.

This PR removes the `set_host` parameter on the app, and is accompanied by this PR in the IAC repo: https://github.com/HUIT-Cloud-Architecture/hcdo-cto-ood-app/pull/107. The PR in the IAC repo sets the `set_host` parameter in the configuration for the cluster, so it no longer needs to be set at the app level.

# References

- [`datascience-notebook` container repo tags](https://quay.io/repository/jupyter/datascience-notebook?tab=tags)
- [`scipy-notebook` container repo tags](https://quay.io/repository/jupyter/scipy-notebook?tab=tags)