### PR TITLE
ECON 2110 course setup

### DIFF
--- a/build/econ2110.def
+++ b/build/econ2110.def
@@ -16,50 +16,10 @@ scipy
 scikit-learn
 stargazer
 statsmodels
+rdrobust
+binsreg
+seaborn
+lpdensity
 EOF
 
 pip install -r /tmp/requirements.txt
-
-R_PACKAGES=(
-    "AER" 
-    "MASS"
-    "boot"
-    "broom"
-    "car"
-    "data.table"
-    "dfadjust"
-    "dplyr"
-    "estimatr"
-    "gamlr"
-    "ggplot2"
-    "haven"
-    "ivDiag"
-    "kableExtra"
-    "lfe"
-    "lib"
-    "lmtest"
-    "lpdensity"
-    "lubridate"
-    "maptpx"
-    "margins"
-    "msm"
-    "np"
-    "nprobust"
-    "oglmx"
-    "randomForest"
-    "rdrobust"
-    "rpart"
-    "rugarch"
-    "sampleSelection"
-    "sandwich"
-    "stargazer"
-    "statar"
-    "textir"
-    "tidyverse"
-    "tm"
-    "zoo")
-
-for package in "${R_PACKAGES[@]}"
-do
-Rscript -e "install.packages(\"${package}\")"
-done

--- a/build/econ2110.def
+++ b/build/econ2110.def
@@ -1,6 +1,6 @@
 Bootstrap:docker
 Registry: quay.io
-From: jupyter/datascience-notebook:lab-4.4,5
+From: jupyter/datascience-notebook:lab-4.4.5
 
 %post
 cat << EOF > /tmp/requirements.txt

--- a/build/econ2110.def
+++ b/build/econ2110.def
@@ -16,10 +16,67 @@ scipy
 scikit-learn
 stargazer
 statsmodels
-rdrobust
-binsreg
-seaborn
-lpdensity
 EOF
 
 pip install -r /tmp/requirements.txt
+
+R_PACKAGES=(
+    "AER" 
+    "MASS"
+    "binsreg"
+    "boot"
+    "broom"
+    "car"
+    "data.table"
+    "dfadjust"
+    "dplyr"
+    "estimatr"
+    "fixest"
+    "gamlr"
+    "ggplot2"
+    "haven"
+    "ivDiag"
+    "jsonlite"
+    "kableExtra"
+    "lfe"
+    "lib"
+    "lmtest"
+    "lpdensity"
+    "lubridate"
+    "maptpx"
+    "margins"
+    "msm"
+    "np"
+    "nprobust"
+    "oglmx"
+    "randomForest"
+    "remotes"
+    "rdrobust"
+    "rpart"
+    "rpart.plot"
+    "rugarch"
+    "ranger"
+    "sampleSelection"
+    "sandwich"
+    "stargazer"
+    "statar"
+    "textir"
+    "tidyverse"
+    "tm"
+    "zoo"
+)
+
+R_GH_PACKAGES=(
+    "OpportunityInsights/oiplot"
+    "grantmcdermott/lfe2fixest"
+    "manutzn/fredo"
+)
+
+for package in "${R_PACKAGES[@]}"
+do
+Rscript -e "install.packages(\"${package}\")"
+done
+
+for package in "${R_GH_PACKAGES[@]}"
+do
+Rscript -e "devtools::install_github(\"${package}\")

--- a/build/jupyter-econ2110.def
+++ b/build/jupyter-econ2110.def
@@ -1,8 +1,11 @@
-Bootstrap:docker
-Registry: quay.io
-From: jupyter/datascience-notebook:lab-4.4.5
+Bootstrap:localimage
+From: /shared/apptainerImages/datascience-notebook.sif
 
-%post
+%post -c /bin/bash
+echo "shell: $0"
+
+apt-get update && apt-get -y install cmake
+
 cat << EOF > /tmp/requirements.txt
 arch
 # fixedeffect # Unclear that this is a python package
@@ -74,9 +77,10 @@ R_GH_PACKAGES=(
 
 for package in "${R_PACKAGES[@]}"
 do
-Rscript -e "install.packages(\"${package}\")"
+Rscript -e "install.packages(\"${package}\", repos=\"https://archive.linux.duke.edu/cran/\")"
 done
 
 for package in "${R_GH_PACKAGES[@]}"
 do
-Rscript -e "devtools::install_github(\"${package}\")
+Rscript -e "devtools::install_github(\"${package}\")"
+done

--- a/build/jupyter-econ2110.def
+++ b/build/jupyter-econ2110.def
@@ -1,5 +1,6 @@
 Bootstrap:localimage
 From: /shared/apptainerImages/datascience-notebook.sif
+# For this build, I pulled from a local image file that had already been created to speed up the build process. I'm not sure if this is something we want to make a more general pattern, though.
 
 %post -c /bin/bash
 echo "shell: $0"

--- a/local/econ2110.yml.erb
+++ b/local/econ2110.yml.erb
@@ -75,7 +75,7 @@ attributes:
   # when starting the app via apptainer. The .sif file must exist at 
   # /shared/apptainerImages. The build definition for any app referenced by a
   # sub-app should be included in the build folder as a .def file.
-  imagefile: "econ2110.sif"
+  imagefile: "jupyter-econ2110.sif"
 
   # How many CPU cores to include in the slurm job submission
   custom_num_cores:

--- a/local/econ2110.yml.erb
+++ b/local/econ2110.yml.erb
@@ -1,0 +1,87 @@
+# Jupyter app user-facing configuration form file (default sub-app)
+# This config file is both an actual configuration file for an actual sample 
+# application, and a starting point for configuring a new sub-app. To make a
+# custom application launch for a course, make a copy of this file in the same 
+# folder and customize the form config to your liking. There are notes along
+# the way to help you understand what options you can make configurable to users.
+# See the docs page from Open OnDemand for more details:
+# https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form.html
+<%-
+# Specify admin groups by the full name of the group in the production HKey environment.
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+# Specify course groups by Canvas course ID, which you can find in a url:
+# canvas.harvard.edu/courses/000000
+enabledGroups = [
+  "156530"
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+cluster: "<%= cluster %>"
+title: "Jupyter Lab - ECON 2110"
+cacheable: false
+
+# Form attributes that will be presented to the user and available to the 
+# scripts that launch the app. Think of this as initializing variables for use 
+# in the attributes section as needed.
+form:
+  - bc_num_hours
+  - bc_queue
+  - imagefile
+  - custom_num_cores
+
+# Customize how form variables appear to users. This is also where you can set 
+# a static value for a variable, in which case it will not be visible to users.
+attributes:
+  # How long will the job run for? Configure min, max, and step to set limits 
+  # on how long app sessions can run.
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 6  # 6 hours max
+    step: 1
+
+  # Which queue to submit to. Usually `general` is the best choice, unless this 
+  # app is configured for a specific EC2 instance type, like an instance type 
+  # with GPU resources.
+  bc_queue: "general"
+
+  # Which Apptainer image file to use. This is used by the script.sh.erb file 
+  # when starting the app via apptainer. The .sif file must exist at 
+  # /shared/apptainerImages. The build definition for any app referenced by a
+  # sub-app should be included in the build folder as a .def file.
+  imagefile: "econ2110.sif"
+
+  # How many CPU cores to include in the slurm job submission
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1

--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -7,9 +7,9 @@ jupyter lab \
            --ip='0.0.0.0' \
            --port="${MY_JUP_PORT}" \
            --port-retries=0 \
-           --NotebookApp.password="${MY_JUP_PASSWD}" \
-           --NotebookApp.base_url="${MY_JUP_BASEURL}" \
+           --ServerApp.PasswordIdentityProvider.hashed_password="${MY_JUP_PASSWD}" \
+           --ServerApp.base_url="${MY_JUP_BASEURL}" \
            --no-browser \
-           --NotebookApp.allow_origin='*' \
-           --NotebookApp.disable_check_xsrf=True \
+           --ServerApp.allow_origin='*' \
+           --ServerApp.disable_check_xsrf=True \
            --WebPDFExporter.disable_sandbox=True


### PR DESCRIPTION
# Overview

Add a course setup for ECON 2110. This app is ready for testing in the production environment, and should be usable by cloning this working branch into your dev apps.

I've validated the basic packages, but given the number of packages in this request, I'm leaving the testing of each to the course staff.

Two packages for R, `lib` and `oglmx`, could not be installed. I can find no indication that `lib` has been an R package, but `oglmx` has been removed from CRAN, per https://cran.r-project.org/web/packages/oglmx/index.html.

# Changes

This adds a container definition for a Jupyter Lab app with both Python and R kernels. The following package installs were requested:

```
Python packages for the Jupyter Hub:
arch, fixedeffect, fredapi, linearmodels, matplotlib, numpy, pandas, rddensity, scipy, scikit-learn, stargazer, statsmodels, rdrobust, binsreg, seaborn, lpdensity


R libraries for the Jupyter Hub (continues on next page):

AER
MASS
binsreg
boot
broom
car
data.table
dfadjust
dplyr
estimatr
fixest
gamlr
ggplot2
haven
ivDiag
jsonlite
kableExtra
lfe
lib
lmtest
lpdensity
lubridate
maptpx
margins
msm
np
nprobust
oglmx
randomForest
remotes
rdrobust
rpart
rpart.plot
rugarch
ranger
sampleSelection
sandwich
stargazer
statar
textir
tidyverse
tm
zoo
devtools::install_github("OpportunityInsights/oiplot")
remotes::install_github("grantmcdermott/lfe2fixest")
devtools::install_github("manutzn/fredo")
```

# Notes

Note that the R package install command had to change to declare an explicit CRAN mirror. There is also a different line for installing packages from GitHub repos, with its own array of input package names.

This PR also includes an update to the Apptainer `%post` section, adding `-c /bin/bash` to explicitly declare a shell app to use in running the steps in the `%post` section. Without this change, there were syntax errors with the array declarations.