### PR TITLE
Bind shared dir to container

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -40,8 +40,7 @@ export APPTAINERENV_APPEND_PATH="/opt/slurm/bin"
 
 ## bind parts of the filesystem to be able to talk to slurm from within the container
 export SING_BINDS=""
-# export SING_BINDS="$SING_BINDS -B /shared/courseSharedFolders"
-# export SING_BINDS="$SING_BINDS -B /shared/spack"
+export SING_BINDS="$SING_BINDS -B /shared"
 # export SING_BINDS="$SING_BINDS -B /etc/nsswitch.conf"
 # export SING_BINDS="$SING_BINDS -B /etc/sssd/"
 # export SING_BINDS="$SING_BINDS -B /var/lib/sss"


### PR DESCRIPTION
# Overview

The folder containing course shared folders was not bound to the Apptainer container. I've made this simpler by just binding the whole /shared dir to the Apptainer container.
