### PR TITLE
Apptainer setup for epsci101 / eps 101

### DIFF
--- a/build/pangeo-notebook.def
+++ b/build/pangeo-notebook.def
@@ -19,4 +19,4 @@ nbconvert
 EOF
 
 # 3. Install Python packages
- pip install -r /tmp/requirements.txt` 
+ pip install -r /tmp/requirements.txt

--- a/build/pangeo-notebook.def
+++ b/build/pangeo-notebook.def
@@ -1,0 +1,22 @@
+Bootstrap: docker
+Registry: quay.io
+From: pangeo/pangeo-notebook:latest
+# Docker image for data analytics notebook from Pangeo - community for big data in the geosciences, see pangeo.io
+
+%post -c /bin/bash
+
+# 1. Install LaTeX and Pandoc for PDF export
+apt-get update && apt-get install -y \
+    texlive-xetex \
+    texlive-fonts-recommended \
+    texlive-plain-generic \
+    pandoc \
+&& apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# 2. Create requirements file
+cat << EOF > /tmp/requirements.txt
+nbconvert
+EOF
+
+# 3. Install Python packages
+ pip install -r /tmp/requirements.txt` 

--- a/build/pangeo-notebook.def
+++ b/build/pangeo-notebook.def
@@ -1,6 +1,6 @@
 Bootstrap: docker
 Registry: quay.io
-From: pangeo/pangeo-notebook:latest
+From: pangeo/pangeo-notebook:2025.12.30
 # Docker image for data analytics notebook from Pangeo - community for big data in the geosciences, see pangeo.io
 
 %post -c /bin/bash

--- a/build/pangeo-notebook.def
+++ b/build/pangeo-notebook.def
@@ -20,3 +20,4 @@ EOF
 
 # 3. Install Python packages
  pip install -r /tmp/requirements.txt
+ 

--- a/local/epsci101.yml.erb
+++ b/local/epsci101.yml.erb
@@ -75,7 +75,7 @@ attributes:
   # when starting the app via apptainer. The .sif file must exist at 
   # /shared/apptainerImages. The build definition for any app referenced by a
   # sub-app should be included in the build folder as a .def file.
-  imagefile: "pangeo-notebook.sif" 
+  imagefile: "pangeo-notebook.sif"
 
   # How many CPU cores to include in the slurm job submission
   custom_num_cores:

--- a/local/epsci101.yml.erb
+++ b/local/epsci101.yml.erb
@@ -1,0 +1,87 @@
+# Jupyter app user-facing configuration form file (default sub-app)
+# This config file is both an actual configuration file for an actual sample 
+# application, and a starting point for configuring a new sub-app. To make a
+# custom application launch for a course, make a copy of this file in the same 
+# folder and customize the form config to your liking. There are notes along
+# the way to help you understand what options you can make configurable to users.
+# See the docs page from Open OnDemand for more details:
+# https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form.html
+<%-
+# Specify admin groups by the full name of the group in the production HKey environment.
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+# Specify course groups by Canvas course ID, which you can find in a url:
+# canvas.harvard.edu/courses/000000
+enabledGroups = [
+  "159536" #EPS 101
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+cluster: "<%= cluster %>"
+title: "Jupyter Lab - EPS 101"
+cacheable: false
+
+# Form attributes that will be presented to the user and available to the 
+# scripts that launch the app. Think of this as initializing variables for use 
+# in the attributes section as needed.
+form:
+  - bc_num_hours
+  - bc_queue
+  - imagefile
+  - custom_num_cores
+
+# Customize how form variables appear to users. This is also where you can set 
+# a static value for a variable, in which case it will not be visible to users.
+attributes:
+  # How long will the job run for? Configure min, max, and step to set limits 
+  # on how long app sessions can run.
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 6  # 6 hours max
+    step: 1
+
+  # Which queue to submit to. Usually `general` is the best choice, unless this 
+  # app is configured for a specific EC2 instance type, like an instance type 
+  # with GPU resources.
+  bc_queue: "general"
+
+  # Which Apptainer image file to use. This is used by the script.sh.erb file 
+  # when starting the app via apptainer. The .sif file must exist at 
+  # /shared/apptainerImages. The build definition for any app referenced by a
+  # sub-app should be included in the build folder as a .def file.
+  imagefile: "pangeo-notebook.sif" 
+
+  # How many CPU cores to include in the slurm job submission
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1


### PR DESCRIPTION
## Overview
Course set up for EPS 101. Pangeo-notebook is a geoscience focused notebook that contains all requested for the course EPS 101 as well as EPS 231 (taught by the same faculty). Given that, created a more general environment that could be used acrossed multiple courses. Additions to the base pangeo-notebook image are Latex, Pandoc, and `nbconvert` to provide the Export as PDF functionality.

## Changes
<details><summary>
```bash
diff -u local/generic.yml.erb local/epsci101.yml.erb
```
</summary>

```bash
--- local/generic.yml.erb       2025-08-29 13:53:08
+++ local/epsci101.yml.erb      2026-01-22 13:41:13
@@ -14,7 +14,7 @@
 # Specify course groups by Canvas course ID, which you can find in a url:
 # canvas.harvard.edu/courses/000000
 enabledGroups = [
-  "135510"
+  "159536" #EPS 101
 ]
 
 def arrays_have_common_element(array1, array2)
@@ -43,7 +43,7 @@
 -%>
 ---
 cluster: "<%= cluster %>"
-title: "Jupyter Lab - Generic (Apptainer)"
+title: "Jupyter Lab - EPS 101"
 cacheable: false
 
 # Form attributes that will be presented to the user and available to the 
@@ -75,7 +75,7 @@
   # when starting the app via apptainer. The .sif file must exist at 
   # /shared/apptainerImages. The build definition for any app referenced by a
   # sub-app should be included in the build folder as a .def file.
-  imagefile: "scipy-notebook.sif"
+  imagefile: "pangeo-notebook.sif" 
 
   # How many CPU cores to include in the slurm job submission
   custom_num_cores:
```
</details>

## Notes

Confirmed via testing scripts that both python packages and PDF and Latex export were working successfully. Attached is the [PDF output for the "EPS101/EPS131 Testing Script"](https://github.com/user-attachments/files/24824616/eps101_and_eps131_testing_script.pdf)


### Testing Packages
<details>
<summary>Python Testing Script</summary>


```
"""
Package Verification & Functionality Test
Written with assistance from Claude 3.5 Sonnet
"""

import sys
import warnings
warnings.filterwarnings('ignore')

print("🧪 Package Tests\n" + "="*50)

tests = []

# Python >= 3.10
tests.append(("Python", sys.version_info >= (3, 10), sys.version.split()[0]))

# pip
try:
    import pip
    tests.append(("pip", True, __import__('importlib.metadata').metadata.version('pip')))
except: tests.append(("pip", False, ""))

# numpy
try:
    import numpy as np
    np.mean([1,2,3])
    tests.append(("numpy", True, np.__version__))
except: tests.append(("numpy", False, ""))

# pandas
try:
    import pandas as pd
    pd.DataFrame({'a':[1,2]}).mean()
    tests.append(("pandas", True, pd.__version__))
except: tests.append(("pandas", False, ""))

# matplotlib
try:
    import matplotlib.pyplot as plt
    fig, ax = plt.subplots(); plt.close()
    tests.append(("matplotlib", True, plt.matplotlib.__version__))
except: tests.append(("matplotlib", False, ""))

# seaborn
try:
    import seaborn as sns
    tests.append(("seaborn", True, sns.__version__))
except: tests.append(("seaborn", False, ""))

# scipy
try:
    from scipy import integrate
    integrate.quad(lambda x: x**2, 0, 1)
    tests.append(("scipy", True, __import__('scipy').__version__))
except: tests.append(("scipy", False, ""))

# requests
try:
    import requests
    requests.get('https://httpbin.org/get', timeout=5)
    tests.append(("requests", True, requests.__version__))
except: tests.append(("requests", False, ""))

# cartopy
try:
    import cartopy.crs as ccrs
    tests.append(("cartopy", True, __import__('cartopy').__version__))
except: tests.append(("cartopy", False, ""))

# gsw
try:
    import gsw
    gsw.SA_from_SP(35.0, 1000, -30, 20)
    tests.append(("gsw", True, gsw.__version__))
except: tests.append(("gsw", False, ""))

# netCDF4
try:
    import netCDF4 as nc
    tests.append(("netCDF4", True, nc.__version__))
except: tests.append(("netCDF4", False, ""))

# jupyterlab
try:
    import jupyterlab
    tests.append(("jupyterlab", True, __import__('importlib.metadata').metadata.version('jupyterlab')))
except: tests.append(("jupyterlab", False, ""))

# Results
for name, passed, ver in tests:
    status = "✅" if passed else "❌"
    print(f"{status} {name:12s} {ver}")

passed = sum(1 for _, p, _ in tests if p)
print(f"\n{'='*50}\n{passed}/{len(tests)} passed", "🎉" if passed == len(tests) else "⚠️")
```
</details>


<details>
<summary>Latex/PDF Testing Script (Markdown Block)</summary>
</br>
To test this out, use a markdown cell in Jupyter. When running the cells or exporting to PDF, the symbols will rendered via Latex.
</br>

```
# LaTeX Stress Test (Geospatial & Scientific)

## 1. Inline Math
The mass-energy equivalence is described by $E=mc^2$.

## 2. Integrals and Greek Letters
The Gaussian integral is famous in statistics:
$$ \int_{-\infty}^{\infty} e^{-x^2} \, dx = \sqrt{\pi} $$

## 3. Matrices (Requires specific amsmath support)
Here is a standard matrix:
$$
A = \begin{bmatrix}
1 & 2 & 3 \\
4 & 5 & 6 \\
7 & 8 & 9
\end{bmatrix}
$$

## 4. Fractions and Sums
$$ \sum_{n=1}^{\infty} \frac{1}{n^2} = \frac{\pi^2}{6} $$

## 5. Thermodynamic Equation of Seawater (GSW / Oceanography)
Testing subscripts, superscripts, and Greek letters common in `gsw`:
$$\rho(S, T, p) = \frac{\rho_0}{1 - p/K(S, T, p)}$$
Where the Gibbs function for seawater is often denoted:
$$g(S, T, p) = g^W(T, p) + g^S(S, T, p)$$

## 6. Integration & Distributions (Scipy / Numpy)
Testing integrals and exponentials used in `scipy.integrate`:
$$\int_{-\infty}^{\infty} e^{-x^2} \, dx = \sqrt{\pi}$$
The Normal Distribution PDF:
$$f(x) = \frac{1}{\sigma \sqrt{2\pi}} e^{-\frac{1}{2} \left(\frac{x-\mu}{\sigma}\right)^2}$$

## 7. Vector Calculus & Coordinates (Cartopy / netCDF)
Testing vector notation, partial derivatives, and spherical coordinates common in geospatial projections:
$$\nabla \cdot \mathbf{v} = \frac{1}{r^2} \frac{\partial}{\partial r} (r^2 v_r) + \frac{1}{r \sin \theta} \frac{\partial}{\partial \theta} (v_\theta \sin \theta) + \frac{1}{r \sin \theta} \frac{\partial v_\phi}{\partial \phi}$$

## 8. Matrices & Tensors (Numpy / Pandas)
Testing matrix rendering (often a failure point for PDF page margins):
$$
\mathbf{X} = \begin{bmatrix}
x_{11} & x_{12} & \cdots & x_{1n} \\
x_{21} & x_{22} & \cdots & x_{2n} \\
\vdots & \vdots & \ddots & \vdots \\
x_{m1} & x_{m2} & \cdots & x_{mn}
\end{bmatrix}
$$
```
</details>

## References
[Pangeo Notebook Image (Quay.io Registry)](https://quay.io/organization/pangeo)
[Pangeo Community](https://pangeo.io/)
[Quay.io Pangeo-Notebook Image Tags](https://quay.io/repository/pangeo/pangeo-notebook?tab=tags&tag=latest)
