### PR TITLE
add config file for ECON 50

### DIFF
--- a/local/econ50.yml.erb
+++ b/local/econ50.yml.erb
@@ -1,0 +1,86 @@
+# Jupyter app user-facing configuration form file (default sub-app)
+# This config file is both an actual configuration file for an actual sample 
+# application, and a starting point for configuring a new sub-app. To make a
+# custom application launch for a course, make a copy of this file in the same 
+# folder and customize the form config to your liking. There are notes along
+# the way to help you understand what options you can make configurable to users.
+# See the docs page from Open OnDemand for more details:
+# https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form.html
+<%-
+# Specify admin groups by the full name of the group in the production HKey environment.
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+# Specify course groups by Canvas course ID, which you can find in a url:
+# canvas.harvard.edu/courses/000000
+enabledGroups = [
+  "159572" # Econ 50
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+cluster: "<%= cluster %>"
+title: "Jupyter Lab - ECON 50"
+
+# Form attributes that will be presented to the user and available to the 
+# scripts that launch the app. Think of this as initializing variables for use 
+# in the attributes section as needed.
+form:
+  - bc_num_hours
+  - bc_queue
+  - imagefile
+  - custom_num_cores
+
+# Customize how form variables appear to users. This is also where you can set 
+# a static value for a variable, in which case it will not be visible to users.
+attributes:
+  # How long will the job run for? Configure min, max, and step to set limits 
+  # on how long app sessions can run.
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 6  # 6 hours max
+    step: 1
+
+  # Which queue to submit to. Usually `general` is the best choice, unless this 
+  # app is configured for a specific EC2 instance type, like an instance type 
+  # with GPU resources.
+  bc_queue: "general"
+
+  # Which Apptainer image file to use. This is used by the script.sh.erb file 
+  # when starting the app via apptainer. The .sif file must exist at 
+  # /shared/apptainerImages. The build definition for any app referenced by a
+  # sub-app should be included in the build folder as a .def file.
+  imagefile: "jupyter-econ1123.sif"
+
+  # How many CPU cores to include in the slurm job submission
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1


### PR DESCRIPTION
# Overview

This PR adds a course setup for ECON 50, which has the same requirements as ECON 1123, so it uses the same container image. I've tested this in prod and confirmed that the app launches in the same way.

# Changes

Comparing setup to ECON 1123, which uses the same Apptainer container.

<details>
<summary><code>diff -u local/econ1123.yml.erb local/econ50.yml.erb</code></summary>

 ```diff
--- local/econ1123.yml.erb      2026-01-27 11:49:02
+++ local/econ50.yml.erb        2026-01-27 11:50:36
@@ -14,7 +14,7 @@
 # Specify course groups by Canvas course ID, which you can find in a url:
 # canvas.harvard.edu/courses/000000
 enabledGroups = [
-  "159573" # Econ 1123
+  "159572" # Econ 50
 ]
 
 def arrays_have_common_element(array1, array2)
@@ -43,7 +43,7 @@
 -%>
 ---
 cluster: "<%= cluster %>"
-title: "Jupyter Lab - ECON 1123"
+title: "Jupyter Lab - ECON 50"
 
 # Form attributes that will be presented to the user and available to the 
 # scripts that launch the app. Think of this as initializing variables for use 
```
</details>
