### PR TITLE
Course setup for apcomp297r

### DIFF
--- a/local/apcomp297r-cpu.yml.erb
+++ b/local/apcomp297r-cpu.yml.erb
@@ -1,0 +1,91 @@
+# Jupyter app user-facing configuration form file (default sub-app)
+# This config file is both an actual configuration file for an actual sample 
+# application, and a starting point for configuring a new sub-app. To make a
+# custom application launch for a course, make a copy of this file in the same 
+# folder and customize the form config to your liking. There are notes along
+# the way to help you understand what options you can make configurable to users.
+# See the docs page from Open OnDemand for more details:
+# https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form.html
+<%-
+# Specify admin groups by the full name of the group in the production HKey environment.
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+# Specify course groups by Canvas course ID, which you can find in a url:
+# canvas.harvard.edu/courses/000000
+enabledGroups = [
+  "162018" #APCOMP 297R
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+cluster: "<%= cluster %>"
+title: "Jupyter Lab - APCOMP 297R (CPU)"
+description: |
+  This app is configured for CPU access for APCOMP 297R.
+
+# Form attributes that will be presented to the user and available to the 
+# scripts that launch the app. Think of this as initializing variables for use 
+# in the attributes section as needed.
+form:
+  - bc_num_hours
+  - bc_queue
+  - imagefile
+  - custom_num_cores
+
+# Customize how form variables appear to users. This is also where you can set 
+# a static value for a variable, in which case it will not be visible to users.
+attributes:
+  # How long will the job run for? Configure min, max, and step to set limits 
+  # on how long app sessions can run.
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 6  # 6 hours max
+    step: 1
+
+  # Which queue to submit to. Usually `general` is the best choice, unless this 
+  # app is configured for a specific EC2 instance type, like an instance type 
+  # with GPU resources.
+  bc_queue: "general"
+
+  # How many GPU GRES resources to include in the job submission.
+  custom_num_gpus: 0
+
+  # Which Apptainer image file to use. This is used by the script.sh.erb file 
+  # when starting the app via apptainer. The .sif file must exist at 
+  # /shared/apptainerImages. The build definition for any app referenced by a
+  # sub-app should be included in the build folder as a .def file.
+  imagefile: "datascience-notebook.sif"
+
+  # How many CPU cores to include in the slurm job submission
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1

--- a/local/apcomp297r-gpu.yml.erb
+++ b/local/apcomp297r-gpu.yml.erb
@@ -1,0 +1,93 @@
+# Jupyter app user-facing configuration form file (default sub-app)
+# This config file is both an actual configuration file for an actual sample 
+# application, and a starting point for configuring a new sub-app. To make a
+# custom application launch for a course, make a copy of this file in the same 
+# folder and customize the form config to your liking. There are notes along
+# the way to help you understand what options you can make configurable to users.
+# See the docs page from Open OnDemand for more details:
+# https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form.html
+<%-
+# Specify admin groups by the full name of the group in the production HKey environment.
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+# Specify course groups by Canvas course ID, which you can find in a url:
+# canvas.harvard.edu/courses/000000
+enabledGroups = [
+  "162018" #APCOMP 297R
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+cluster: "<%= cluster %>"
+title: "Jupyter Lab - APCOMP 297R (CPU)"
+description: |
+  This app is configured for CPU access for APCOMP 297R.
+
+# Form attributes that will be presented to the user and available to the 
+# scripts that launch the app. Think of this as initializing variables for use 
+# in the attributes section as needed.
+form:
+  - bc_num_hours
+  - bc_queue
+  - imagefile
+  - custom_num_cores
+
+# Customize how form variables appear to users. This is also where you can set 
+# a static value for a variable, in which case it will not be visible to users.
+attributes:
+  # How long will the job run for? Configure min, max, and step to set limits 
+  # on how long app sessions can run.
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 6  # 6 hours max
+    step: 1
+
+  # Which queue to submit to. Usually `general` is the best choice, unless this 
+  # app is configured for a specific EC2 instance type, like an instance type 
+  # with GPU resources.
+  bc_queue: "gpu"
+
+  # How many CPU cores to include in the slurm job submission
+  custom_num_cores: 12
+  # How many GPU GRES resources to include in the job submission.
+  custom_num_gpus: 1
+
+  # Which Apptainer image file to use. This is used by the script.sh.erb file 
+  # when starting the app via apptainer. The .sif file must exist at 
+  # /shared/apptainerImages. The build definition for any app referenced by a
+  # sub-app should be included in the build folder as a .def file.
+  imagefile: "datascience-notebook.sif"
+
+  # How many CPU cores to include in the slurm job submission
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1

--- a/local/apcomp297r-gpu.yml.erb
+++ b/local/apcomp297r-gpu.yml.erb
@@ -45,7 +45,7 @@ end
 cluster: "<%= cluster %>"
 title: "Jupyter Lab - APCOMP 297R (GPU)"
 description: |
-  This app is configured for CPU access for APCOMP 297R.
+  This app is configured for GPU access for APCOMP 297R.
 
 # Form attributes that will be presented to the user and available to the 
 # scripts that launch the app. Think of this as initializing variables for use 
@@ -83,4 +83,3 @@ attributes:
   # /shared/apptainerImages. The build definition for any app referenced by a
   # sub-app should be included in the build folder as a .def file.
   imagefile: "datascience-notebook.sif"
-  

--- a/local/apcomp297r-gpu.yml.erb
+++ b/local/apcomp297r-gpu.yml.erb
@@ -43,7 +43,7 @@ end
 -%>
 ---
 cluster: "<%= cluster %>"
-title: "Jupyter Lab - APCOMP 297R (CPU)"
+title: "Jupyter Lab - APCOMP 297R (GPU)"
 description: |
   This app is configured for CPU access for APCOMP 297R.
 

--- a/local/apcomp297r-gpu.yml.erb
+++ b/local/apcomp297r-gpu.yml.erb
@@ -83,12 +83,4 @@ attributes:
   # /shared/apptainerImages. The build definition for any app referenced by a
   # sub-app should be included in the build folder as a .def file.
   imagefile: "datascience-notebook.sif"
-
-  # How many CPU cores to include in the slurm job submission
-  custom_num_cores:
-    widget: "number_field"
-    label: "Number of CPUs"
-    value: 1
-    min: 1
-    max: 4
-    step: 1
+  

--- a/local/apcomp297r-gpu.yml.erb
+++ b/local/apcomp297r-gpu.yml.erb
@@ -55,6 +55,7 @@ form:
   - bc_queue
   - imagefile
   - custom_num_cores
+  - custom_num_gpus
 
 # Customize how form variables appear to users. This is also where you can set 
 # a static value for a variable, in which case it will not be visible to users.

--- a/original.submit.yml.erb
+++ b/original.submit.yml.erb
@@ -1,0 +1,7 @@
+---
+batch_connect:
+  template: "basic"
+script:
+  native:
+    - "--nodes=1"
+    - "--cpus-per-task=<%= custom_num_cores.blank? ? 1 : custom_num_cores.to_i %>"

--- a/original.submit.yml.erb
+++ b/original.submit.yml.erb
@@ -1,7 +1,0 @@
----
-batch_connect:
-  template: "basic"
-script:
-  native:
-    - "--nodes=1"
-    - "--cpus-per-task=<%= custom_num_cores.blank? ? 1 : custom_num_cores.to_i %>"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,5 +1,4 @@
 # Job submission configuration file
-# Source ood-jupyterlab-spack-mamba.
 ---
 
 <%-

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,7 +1,28 @@
+# Job submission configuration file
+# Source ood-jupyterlab-spack-mamba.
 ---
+
+<%-
+if custom_num_gpus.blank?
+  gpuArg = ""
+else
+  gpuArg = "- \"--gpus-per-node=#{custom_num_gpus.to_i}\""
+end
+-%>
+
+#
+# Configure the content of the job script for the batch job here
+# @see http://www.rubydoc.info/gems/ood_core/OodCore/BatchConnect/Template
+#
 batch_connect:
   template: "basic"
+
+#
+# Configure the job script submission parameters for the batch job here
+# @see http://www.rubydoc.info/gems/ood_core/OodCore/Job/Script
+#
 script:
   native:
     - "--nodes=1"
     - "--cpus-per-task=<%= custom_num_cores.blank? ? 1 : custom_num_cores.to_i %>"
+    <%= gpuArg.to_s %>


### PR DESCRIPTION
## Overview
Course setup for AP COMP 297r. Requested Jupyterlab with R and Python and access to GPU, without listing any specific packages, so used the datascience-notebook.sif (needed to rebuild the Apptainer in Stage for testing).

## Changes

#### - Updated `submit.yml.erb` to handle `custom_num_gpus` attribute for the GPU apptainer

<details><summary>diff --color -u original.submit.yml.erb submit.yml.erb</summary>

```diff
+end
+-%>
+
+#
+# Configure the content of the job script for the batch job here
+# @see http://www.rubydoc.info/gems/ood_core/OodCore/BatchConnect/Template
+#
 batch_connect:
   template: "basic"
+
+#
+# Configure the job script submission parameters for the batch job here
+# @see http://www.rubydoc.info/gems/ood_core/OodCore/Job/Script
+#
 script:
   native:
     - "--nodes=1"
-    - "--cpus-per-task=<%= custom_num_cores.blank? ? 1 : custom_num_cores.to_i %>"
\ No newline at end of file
+    - "--cpus-per-task=<%= custom_num_cores.blank? ? 1 : custom_num_cores.to_i %>"
+    <%= gpuArg.to_s %>
```
</details> 


#### - Added `apcomp297r-cpu.yml.erb` to handle CPU
 <details><summary>diff --color -u  generic.yml.erb apcomp297r-gpu.yml.erb</summary>

```diff
--- generic.yml.erb     2026-01-30 15:11:03
+++ apcomp297r-gpu.yml.erb      2026-01-30 16:39:58
@@ -14,7 +14,7 @@
 # Specify course groups by Canvas course ID, which you can find in a url:
 # canvas.harvard.edu/courses/000000
 enabledGroups = [
-  "135510"
+  "162018" #APCOMP 297R
 ]
 
 def arrays_have_common_element(array1, array2)
@@ -43,7 +43,9 @@
 -%>
 ---
 cluster: "<%= cluster %>"
-title: "Jupyter Lab - Generic (Apptainer)"
+title: "Jupyter Lab - APCOMP 297R (CPU)"
+description: |
+  This app is configured for CPU access for APCOMP 297R.
 
 # Form attributes that will be presented to the user and available to the 
 # scripts that launch the app. Think of this as initializing variables for use 
@@ -53,6 +55,7 @@
   - bc_queue
   - imagefile
   - custom_num_cores
+  - custom_num_gpus
 
 # Customize how form variables appear to users. This is also where you can set 
 # a static value for a variable, in which case it will not be visible to users.
@@ -68,13 +71,18 @@
   # Which queue to submit to. Usually `general` is the best choice, unless this 
   # app is configured for a specific EC2 instance type, like an instance type 
   # with GPU resources.
-  bc_queue: "general"
+  bc_queue: "gpu"
 
+  # How many CPU cores to include in the slurm job submission
+  custom_num_cores: 12
+  # How many GPU GRES resources to include in the job submission.
+  custom_num_gpus: 1
+
   # Which Apptainer image file to use. This is used by the script.sh.erb file 
   # when starting the app via apptainer. The .sif file must exist at 
   # /shared/apptainerImages. The build definition for any app referenced by a
   # sub-app should be included in the build folder as a .def file.
-  imagefile: "scipy-notebook.sif"
+  imagefile: "datascience-notebook.sif"
 
   # How many CPU cores to include in the slurm job submission
   custom_num_cores:
```
</details>


#### - Added `apcomp297r-gpu.yml.erb` to handle GPU
<details> <summary> diff --color -u  generic.yml.erb apcomp297r-gpu.yml.erb </summary>

```diff
--- local/generic.yml.erb       2026-01-30 15:11:03
+++ local/apcomp297r-gpu.yml.erb        2026-02-02 04:29:24
@@ -14,7 +14,7 @@
 # Specify course groups by Canvas course ID, which you can find in a url:
 # canvas.harvard.edu/courses/000000
 enabledGroups = [
-  "135510"
+  "162018" #APCOMP 297R
 ]
 
 def arrays_have_common_element(array1, array2)
@@ -43,7 +43,9 @@
 -%>
 ---
 cluster: "<%= cluster %>"
-title: "Jupyter Lab - Generic (Apptainer)"
+title: "Jupyter Lab - APCOMP 297R (GPU)"
+description: |
+  This app is configured for GPU access for APCOMP 297R.
 
 # Form attributes that will be presented to the user and available to the 
 # scripts that launch the app. Think of this as initializing variables for use 
@@ -53,6 +55,7 @@
   - bc_queue
   - imagefile
   - custom_num_cores
+  - custom_num_gpus
 
 # Customize how form variables appear to users. This is also where you can set 
 # a static value for a variable, in which case it will not be visible to users.
@@ -68,19 +71,15 @@
   # Which queue to submit to. Usually `general` is the best choice, unless this 
   # app is configured for a specific EC2 instance type, like an instance type 
   # with GPU resources.
-  bc_queue: "general"
+  bc_queue: "gpu"
 
+  # How many CPU cores to include in the slurm job submission
+  custom_num_cores: 12
+  # How many GPU GRES resources to include in the job submission.
+  custom_num_gpus: 1
+
   # Which Apptainer image file to use. This is used by the script.sh.erb file 
   # when starting the app via apptainer. The .sif file must exist at 
   # /shared/apptainerImages. The build definition for any app referenced by a
   # sub-app should be included in the build folder as a .def file.
-  imagefile: "scipy-notebook.sif"
-
-  # How many CPU cores to include in the slurm job submission
-  custom_num_cores:
-    widget: "number_field"
-    label: "Number of CPUs"
-    value: 1
-    min: 1
-    max: 4
-    step: 1
+  imagefile: "datascience-notebook.sif"
```
</details>




## Notes

I set up this course with the `datascience-notebook.sif` image based on generalized faculty [course Request](https://harvard.enterprise.slack.com/lists/T02EW8A5W/F085BTEGL02?record_id=Rec0AAH0DV89J). I highlighted the key details below and Included full course request form in drop down below:

#### Key details
 - **What apps does your class need?:** Jupyter Lab (Python and R) via HUIT Open OnDemand
 - **Packages and Kernels that need to be pre-installed:** [Blank]
 - **Specialized needs (GPUs, remote desktop applications, etc.):** Some of the students will potentially need GPUs for AI applications, but they should be able to use whatever software you already use for other courses here.


<details><summary>Full Course Request Details</summary>


```bash
Customer: cat@seas.harvard.edu

AssignedGroup: FAS Academic Technology

Service: Computing Platforms > Open OnDemand

Category: Request

ShortDescription: New academic compute request for APCOMP 297R: Computational Science and Engineering Capstone Project

Description:The academic compute request form has a new request. Here is the response in full:

====================
Email address
-----------------------
cat@seas.harvard.edu
====================

Canvas course ID (canvas.harvard.edu/courses/XXXXXX)

You can find your Canvas site by clicking the "course site" link at [my.harvard.edu](https://my.harvard.edu/). Please include only the numbers at the end, rather than the full link.
-----------------------
162018
====================
Canvas course title
-----------------------
APCOMP 297R: Computational Science and Engineering Capstone Project
====================
Is this course cross-listed?

If yes, please provide the cross-listed course title / code. If no, just write "N/A".
-----------------------
N/A
====================
What is your role in this course?
-----------------------
Instructor
====================
What apps does your class need?
-----------------------
Jupyter Lab (Python and R) via HUIT Open OnDemand
====================
Packages and Kernels that need to be pre-installed

If you are only requesting access to RStudio via Posit, you can skip this section, as Posit allows users to manage their own R packages.

If requesting multiple apps, please specify which packages belong to which apps, e.g. Python: pandas, numpy, matplotlib; R: tidyverse
-----------------------

====================
Specialized needs (e.g. GPUs, remote desktop applications, etc.)

If you have any specialized needs, such as for GPUs or for specialized software beyond Python or R packages, please describe them here.
-----------------------
Some of the students will potentially need GPUs for AI applications, but they should be able to use whatever software you already use for other courses here.
====================
Primary point of contact on the teaching staff

Please provide at least one name and email address for questions and coordination.
-----------------------
Christopher Thorpe, cat@seas.harvard.edu
====================
Expected course enrollment
-----------------------
20 - 49
====================
What is the first date that you plan to use compute resources?

Enter the date as mm/dd/yyyy

Compute resources are normally installed on course sites in 10 business days; please request the tool early to ensure access to the platform on time.
-----------------------
02/04/2026
====================
Expected usage patterns for the course

(E.g., is there a large final project, a 24-hour exam period potentially needing off-hour support, etc.?)
-----------------------
The entire course is a project, so usage patterns should be fairly regular though I expect a "crunch time" right before spring break as a checkin is due then, and probably another one around reading period as students get ready to end the course.
====================
```
</details>

GPU access was not apart of the apptainer setup, so followed pattern establish by @Tanvez  in `ood-jupyterlab-spack-mamba` generally, and specifically in [PR#5](https://github.com/Harvard-ATG/ood-jupyterlab-spack-mamba/pull/5) to update `submit.yml.erb`. 

Also added the course to the GPU queue in [HUIT-Cloud-Architecture/hcdo-cto-ood-app PR #33](https://github.com/HUIT-Cloud-Architecture/hcdo-cto-ood-app/pull/133). Used [hcdo-cto-ood-app #PR131](https://github.com/HUIT-Cloud-Architecture/hcdo-cto-ood-app/pull/131) as guidance.

