### PR TITLE
Fix/load pangeo from scratch lustre

### DIFF
--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -3,6 +3,21 @@
 # Run pyppeteer install to fix issue with exporting to pdf
 # pyppeteer-install
 
+# -------------------------------------------------------------------------
+# OPTIONAL: DISABLE HEAVY EXTENSIONS [DEACTIVATED]
+# -------------------------------------------------------------------------
+# CONTEXT:
+# The Jupyter Extension Manager attempts to fetch updates from the internet 
+# every time the notebook starts. This consumes significant CPU cycles (100% core usage)
+# for 2-4 seconds during startup.
+#
+# HOW TO ENABLE:
+# Uncomment the line below. This is recommended if running on small nodes 
+# (e.g., 1-2 CPUs) to prevent startup crashes or sluggishness.
+# -------------------------------------------------------------------------
+DISABLE_FLAGS=""
+# DISABLE_FLAGS="--LabApp.disabled_extensions='@jupyterlab/extensionmanager-extension'"
+
 jupyter lab \
            --ip='0.0.0.0' \
            --port="${MY_JUP_PORT}" \

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -41,13 +41,9 @@ JUPYTER_TMPDIR=${TMPDIR:-/tmp}/$(id -un)-jupyter/
 WORKDIR=/scratch/${USER}/${SLURM_JOB_ID}
 mkdir -m 700 -p ${WORKDIR}/tmp
 
-# OPTIONAL: Set Up Scratch/Lustre Working Directory for Jupyter Cache, Runtime, Temp"
-# We use SLURM_JOB_ID to create a unique, disposable scratch folder for every job.
-# This prevents permission conflicts if a user runs multiple jobs.
-# TO ENABLE: Uncomment the 2 lines below.
+# OPTIONAL: Set Up Scratch/Lustre Working Directory for Jupyter Cache, and Runtime"
 # -------------------------------------------------------------------------
-# WORKDIR="/scratch/${USER}/${SLURM_JOB_ID}"
-# mkdir -m 700 -p "${WORKDIR}"/{runtime,cache,tmp}
+# mkdir -m 700 -p "${WORKDIR}"/{runtime,cache}
 
 # OPTIONAL: REDIRECT JUPYTER CACHE, RUNTIME, and TMP to Scratch/Lustre
 # This prevents heavy I/O on EFS home directories.

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -77,6 +77,7 @@ export APPTAINERENV_APPEND_PATH="/opt/slurm/bin"
 ## bind parts of the filesystem to be able to talk to slurm from within the container
 export SING_BINDS=""
 export SING_BINDS="$SING_BINDS -B /shared"
+export SING_BINDS="$SING_BINDS -B /scratch"
 # export SING_BINDS="$SING_BINDS -B /etc/nsswitch.conf"
 # export SING_BINDS="$SING_BINDS -B /etc/sssd/"
 # export SING_BINDS="$SING_BINDS -B /var/lib/sss"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -12,17 +12,51 @@ log "Starting main script"
 # Set working directory to home directory
 cd "${HOME}"
 
+# Define Image Path 
+# Only pangeo-notebook.sif has been migrated to Lustre (/scratch). 
+# All other images should default to the EFS (/shared) location for safety.
+
+# The image selected passed in via the context variable 'imagefile'
+IMAGE_FILE="<%= context.imagefile %>"
+
+if [[ "$IMAGE_FILE" == "pangeo-notebook.sif" ]]; then
+    # FAST PATH (Lustre)
+    log "Image is Pangeo Notebook, using Lustre path for container image."
+    export container_folder=/scratch/apptainerImages/
+else
+    # STANDARD PATH (EFS)
+    log "Image is ${IMAGE_FILE}, using standard EFS path for container image."
+    export container_folder=/shared/apptainerImages
+fi
+
+
 # Set up location of apptainer image
-export container_folder=/shared/apptainerImages
 ## when you test new installs you probaby want to drop the images locally in your home folder
 #export container_folder=$HOME/Programs/containers
-export container_image=$container_folder/<%= context.imagefile %>
+export container_image=$container_folder/$IMAGE_FILE
 
-# Set additional variables
-JUPYTER_TMPDIR=${TMPDIR:-/tmp}/$(id -un)-jupyter/
-## job specific tmp in case there are conflicts with different users running on the same node
-WORKDIR=/scratch/${USER}/${SLURM_JOB_ID}
-mkdir -m 700 -p ${WORKDIR}/tmp
+# OPTIONAL: Set Up Scratch/Lustre Working Directory for Jupyter Cache, Runtime, Temp"
+# We use SLURM_JOB_ID to create a unique, disposable scratch folder for every job.
+# This prevents permission conflicts if a user runs multiple jobs.
+# TO ENABLE: Uncomment the 2 lines below.
+# -------------------------------------------------------------------------
+# WORKDIR="/scratch/${USER}/${SLURM_JOB_ID}"
+# mkdir -m 700 -p "${WORKDIR}"/{runtime,cache,tmp}
+
+# OPTIONAL: REDIRECT JUPYTER CACHE, RUNTIME, and TMP to Scratch/Lustre
+# This prevents heavy I/O on EFS home directories.
+# Jupyter writes frequent "heartbeat" files, sockets, and logs. By default, 
+# these go to the user's Home directory (EFS). 
+# If a large class (50+ students) launches simultaneously, thousands of tiny 
+# writes can hit the EFS IOPS limit, causing the storage to "freeze" for everyone.
+# TO ENABLE: Uncomment the block below to force these temporary files onto Lustre.
+# This isolates the I/O load and protects the Home directory.
+# -------------------------------------------------------------------------
+# export APPTAINERENV_JUPYTER_RUNTIME_DIR="${WORKDIR}/runtime"
+# export APPTAINERENV_XDG_CACHE_HOME="${WORKDIR}/cache"
+# export APPTAINERENV_TMPDIR="${WORKDIR}/tmp"
+
+
 
 # Create environment variables to pass to singularity container
 # See https://apptainer.org/docs/user/latest/appendix.html#e for info

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -35,6 +35,12 @@ fi
 #export container_folder=$HOME/Programs/containers
 export container_image=$container_folder/$IMAGE_FILE
 
+# Set additional variables
+JUPYTER_TMPDIR=${TMPDIR:-/tmp}/$(id -un)-jupyter/
+## job specific tmp in case there are conflicts with different users running on the same node
+WORKDIR=/scratch/${USER}/${SLURM_JOB_ID}
+mkdir -m 700 -p ${WORKDIR}/tmp
+
 # OPTIONAL: Set Up Scratch/Lustre Working Directory for Jupyter Cache, Runtime, Temp"
 # We use SLURM_JOB_ID to create a unique, disposable scratch folder for every job.
 # This prevents permission conflicts if a user runs multiple jobs.


### PR DESCRIPTION
## Overview

This PR optimizes the JupyterLab startup process by migrating the storage backend for the `pangeo-notebook` image.

The primary performance win comes purely from the **Lustre storage migration (0.5s load)**. Further optimizations to Python runtime yielded diminishing returns.

* **Primary Fix:** Conditionally points the container image path to Lustre (`/scratch`) instead of EFS (`/shared`) when the Pangeo image is selected.

* **Secondary Changes:** Adds documentation blocks and optional flags for "Performance Tuning" (Extensions/Cache redirection) but leaves them **deactivated by default** based on stability findings.

## Changes: 

**Logic Added:**
Introduced a conditional check to `template/script.sh.erb` (main fix) and switch storage paths based on the image name. This allows `pangeo-notebook.sif` to load from high-speed Lustre storage while keeping other images on the standard EFS share for safety.

```bash
# Define Image Path 
# Only pangeo-notebook.sif has been migrated to Lustre (/scratch). 
# All other images should default to the EFS (/shared) location for safety.

IMAGE_FILE="<%= context.imagefile %>"

if [[ "$IMAGE_FILE" == "pangeo-notebook.sif" ]]; then
    # FAST PATH (Lustre)
    log "Image is Pangeo Notebook, using Lustre path for container image."
    export container_folder=/scratch/apptainerImages/
else
    # STANDARD PATH (EFS)
    log "Image is ${IMAGE_FILE}, using standard EFS path for container image."
    export container_folder=/shared/apptainerImages
fi

export container_image=$container_folder/$IMAGE_FILE

```

**Binds Added:**
Ensured `/scratch` is available inside the container.

```bash
export SING_BINDS="$SING_BINDS -B /scratch"

```

**Optional Optimization - Use Scratch for Jupyter Cache, Runtime, and Temp (Deactivated):**
Added a commented-out block for redirecting Jupyter runtime files to Lustre.

```bash
# OPTIONAL: REDIRECT JUPYTER CACHE, RUNTIME, and TMP to Scratch/Lustre
# ...
# export APPTAINERENV_JUPYTER_RUNTIME_DIR="${WORKDIR}/runtime"
# export APPTAINERENV_XDG_CACHE_HOME="${WORKDIR}/cache"
# export APPTAINERENV_TMPDIR="${WORKDIR}/tmp"

```

---


**Optional Optimization - Use Scratch for Jupyter Cache, Runtime, and Temp (Deactivated):**
There are about 20 extensions that are loaded for jupyter notebook. All of these are likely not necessary.  I added one example below, "CPU spike" caused by the Extension Manager, but left the actual disable flag commented out. Other p

```bash
# -------------------------------------------------------------------------
# OPTIONAL: DISABLE HEAVY EXTENSIONS [DEACTIVATED]
# -------------------------------------------------------------------------
# CONTEXT:
# The Jupyter Extension Manager attempts to fetch updates from the internet 
# every time the notebook starts. This consumes significant CPU cycles.
# ...
# -------------------------------------------------------------------------
DISABLE_FLAGS=""
# DISABLE_FLAGS="--LabApp.disabled_extensions='@jupyterlab/extensionmanager-extension'"

```

---

### **4. Testing Report & Observations**

**A. Storage Migration (Lustre vs EFS)**

* **Method:** Compared container cold-start time (Apptainer load) using `pangeo-notebook.sif` on EFS (`/shared`) versus Lustre (`/scratch`).
* **Data:**
* **EFS Load Time:** ~5.0 seconds
* **Lustre Load Time:** **~0.5 seconds** (10x improvement).


* **Simulation:** Synthetic tests (writing 2GB file + 1000 small files) confirmed Lustre's throughput advantage (594 MB/s vs 103 MB/s), validating why the large SIF file loads significantly faster.

**B. Runtime/Cache Redirection (Optional Block)**

* **Method:** Redirected Jupyter's ephemeral directories (`runtime`, `cache`, `tmp`) to Lustre to mitigate metadata overhead.
* **Data:**
* **Standard:** ~0.6 seconds overhead.
* **Redirection:** **~0.5 seconds** overhead.


* **Conclusion:** The gain (~0.1s) was negligible compared to the added complexity, so this remains disabled by default.

**C. Extension Disabling (Python Overhead)**

* **Method:** Tested disabling extensions from loading by adding a json config in jupyter script.
* **Data:** Total startup time remained around **~4.0 seconds** when activating python regardless of whether extensions were disabled or enabled.
* **Issue:** Removing extensions via CLI caused UI "Missing Extension" pop-ups and connection lag, which negatively impacted the user experience without providing a speed benefit.
* **Decision:** Default extensions are kept enabled for stability.

## References
- [Pylance](https://github.com/microsoft/pylance-release/issues/4022): Artie's testing and a number or references indicate Jupyter Extensions cause high CPU/IO usage by fetching updates at startup.
- [Jupyter-Notebook.readthedocs.io](https://jupyter-notebook.readthedocs.io/en/stable/troubleshooting.html#jupyter-doesn-t-load-or-doesn-t-work-in-the-browser): Notes that Suggests to disabled browser extensions and Jupyter extensions if browswer doesn't load. 
- [Jupyter-Notebook.readthedocs.io Extensions Disclaimer](https://jupyterlab.readthedocs.io/en/stable/user/extensions.html#disclaimer): "Installing an extension allows it to execute arbitrary code on the server, kernel, and the browser. Therefore, we ask you to explicitly acknowledge this."