### PR TITLE
Optimize jupyterlab scratch and extensions use for EPS 101 and EPS 131

### DIFF
--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -42,11 +42,21 @@ PASSWORD="${MY_JUP_PASSWD}"
 
 
 # --- 2. FRONTEND CONFIG: disable Lab extensions via page_config.json ---
-# FIX: Separated the variable definition from the mkdir command
+
+
+
+# --- 3. GENERATE RUNTIME CONFIGURATION FILE ---
+# MOVING AWAY FROM: Passing raw CLI flags (e.g., --ip, --port) which may be prone 
+#                  to shell-escaping errors and cause "Missing Extension" popups.
+#
+# MOVING TOWARD:   A generated Python config file to 
+#                  simultaneously disable Backend and Frontend components to 
+#                  fix UI sluggishness and icon "lag."
+# -----------------------------------------------------------------------------
+# Creat e Jupyter Lab frontend config directory if it doesn't exist
 LABCONFIG_DIR="${HOME}/.jupyter/labconfig"
 mkdir -p "${LABCONFIG_DIR}"
 
-# We use quoted 'EOF' to prevent any accidental shell expansion in the JSON
 cat > "${LABCONFIG_DIR}/page_config.json" <<'EOF'
 {
   "disabledExtensions": {
@@ -62,15 +72,7 @@ cat > "${LABCONFIG_DIR}/page_config.json" <<'EOF'
 }
 EOF
 
-
-# --- 3. GENERATE RUNTIME CONFIGURATION FILE ---
-# MOVING AWAY FROM: Passing raw CLI flags (e.g., --ip, --port) which may be prone 
-#                  to shell-escaping errors and cause "Missing Extension" popups.
-#
-# MOVING TOWARD:   A generated Python config file to 
-#                  simultaneously disable Backend and Frontend components to 
-#                  fix UI sluggishness and icon "lag."
-# -----------------------------------------------------------------------------
+# Create a temporary Jupyter config file for the server settings
 CONF_FILE="${PWD}/jupyter_server_config.py"
 
 cat <<EOF > "${CONF_FILE}"
@@ -101,17 +103,6 @@ c.ServerApp.jpserver_extensions = {
     'nbgitpuller': False,                   # External sync service
     'panel.io.jupyter_server_extension': False # Dask-related, heavy JS load
 }
-
-# B. FRONTEND: Stop the Browser from requesting these icons (Fixes rendering lag)
-# By matching this list with the backend above, we prevent "Extension Missing" popups.
-c.LabConfig.disabled_extensions = [
-    '@jupyterlab/extensionmanager-extension', # Goal to prevents CPU spike on startup
-    '@jupyterlab/git',                        # Removes sidebar Git icon, git can be handled via terminal
-    '@jupyterlab/github',                     # Removes sidebar GitHub icon, git can be handled via terminal
-    '@jupyterlab/google-drive',                # Removes sidebar Drive icon, prevents heavy Google API calls
-    'dask-labextension',                      # Removes sidebar Dask icon, Dask can still be used via terminal or code
-    'jupyter-leaflet'                         # Prevents heavy GIS JS load, static maps can still be used in notebooks
-]
 EOF
 
 

--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -89,7 +89,9 @@ c.LabApp.disabled_extensions = [
     '@jupyterlab/google-drive',                # Removes sidebar Drive icon, prevents heavy Google API calls
     'dask-labextension',                      # Removes sidebar Dask icon, Dask can still be used via terminal or code
     'jupyter-leaflet'                         # Prevents heavy GIS JS load, static maps can still be used in notebooks
+]
 EOF
+
 
 # --- 3. LAUNCH JUPYTER ---
 # MOVING AWAY FROM: 'jupyter lab [flags]'

--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -15,16 +15,87 @@
 # Uncomment the line below. This is recommended if running on small nodes 
 # (e.g., 1-2 CPUs) to prevent startup crashes or sluggishness.
 # -------------------------------------------------------------------------
-DISABLE_FLAGS=""
-# DISABLE_FLAGS="--LabApp.disabled_extensions='@jupyterlab/extensionmanager-extension'"
+# DISABLE_FLAGS=""
+# # DISABLE_FLAGS="--LabApp.disabled_extensions='@jupyterlab/extensionmanager-extension'"
 
-jupyter lab \
-           --ip='0.0.0.0' \
-           --port="${MY_JUP_PORT}" \
-           --port-retries=0 \
-           --ServerApp.PasswordIdentityProvider.hashed_password="${MY_JUP_PASSWD}" \
-           --ServerApp.base_url="${MY_JUP_BASEURL}" \
-           --no-browser \
-           --ServerApp.allow_origin='*' \
-           --ServerApp.disable_check_xsrf=True \
-           --WebPDFExporter.disable_sandbox=True
+# jupyter lab \
+#            --ip='0.0.0.0' \
+#            --port="${MY_JUP_PORT}" \
+#            --port-retries=0 \
+#            --ServerApp.PasswordIdentityProvider.hashed_password="${MY_JUP_PASSWD}" \
+#            --ServerApp.base_url="${MY_JUP_BASEURL}" \
+#            --no-browser \
+#            --ServerApp.allow_origin='*' \
+#            --ServerApp.disable_check_xsrf=True \
+#            --WebPDFExporter.disable_sandbox=True
+
+
+# -------------------------------------------------------------------------
+# OPTIMIZED LAUNCH SCRIPT WITH SCRATCH/LUSTRE REDIRECTION
+# -------------------------------------------------------------------------
+# Optimized for Luster and High-Concurrency I/O Classes.
+
+# --- 1. SET UP PARAMETERS ---
+PORT="${MY_JUP_PORT:-8888}"
+BASE_URL="${MY_JUP_BASEURL:-/}"
+PASSWORD="${MY_JUP_PASSWD}"
+
+
+# --- 2. GENERATE RUNTIME CONFIGURATION FILE ---
+# MOVING AWAY FROM: Passing raw CLI flags (e.g., --ip, --port) which may be prone 
+#                  to shell-escaping errors and cause "Missing Extension" popups.
+#
+# MOVING TOWARD:   A generated Python config file to 
+#                  simultaneously disable Backend and Frontend components to 
+#                  fix UI sluggishness and icon "lag."
+# -----------------------------------------------------------------------------
+CONF_FILE="${PWD}/jupyter_server_config.py"
+
+cat <<EOF > "${CONF_FILE}"
+c = get_config()
+
+# --- NETWORK & SECURITY ---
+c.ServerApp.ip = '0.0.0.0'
+c.ServerApp.port = ${PORT}
+c.ServerApp.port_retries = 0
+c.ServerApp.base_url = '${BASE_URL}'
+c.ServerApp.PasswordIdentityProvider.hashed_password = '${PASSWORD}'
+c.ServerApp.allow_origin = '*'
+c.ServerApp.disable_check_xsrf = True
+c.ServerApp.open_browser = False
+c.WebPDFExporter.disable_sandbox = True
+
+# --- UI & PERFORMANCE OPTIMIZATION (THE "ICON & POPUP" FIX) ---
+# MOVING AWAY FROM: Default loading of all sidebar extensions.
+# MOVING TOWARD:   Explicitly disabling high-I/O extensions. This prevents the 
+#                  browser from "searching" for icons and status updates on 
+#                  slow storage, which fixes the "Sluggish Icon" effect.
+
+# A. BACKEND: Stop the Python server from loading these plugins (Saves RAM/CPU)
+c.ServerApp.jpserver_extensions = {
+    'dask_labextension': False,             # Constantly polls cluster status
+    'jupyter_server_xarray_leaflet': False, # Heavy GIS metadata calls
+    'jupyterlab_git': False,                # Crawls file tree for .git folders
+    'nbgitpuller': False,                   # External sync service
+    'panel.io.jupyter_server_extension': False # Dask-related, heavy JS load
+}
+
+# B. FRONTEND: Stop the Browser from requesting these icons (Fixes rendering lag)
+# By matching this list with the backend above, we prevent "Extension Missing" popups.
+c.LabApp.disabled_extensions = [
+    '@jupyterlab/extensionmanager-extension', # Goal to prevents CPU spike on startup
+    '@jupyterlab/git',                        # Removes sidebar Git icon, git can be handled via terminal
+    '@jupyterlab/github',                     # Removes sidebar GitHub icon, git can be handled via terminal
+    '@jupyterlab/google-drive',                # Removes sidebar Drive icon, prevents heavy Google API calls
+    'dask-labextension',                      # Removes sidebar Dask icon, Dask can still be used via terminal or code
+    'jupyter-leaflet'                         # Prevents heavy GIS JS load, static maps can still be used in notebooks
+EOF
+
+# --- 3. LAUNCH JUPYTER ---
+# MOVING AWAY FROM: 'jupyter lab [flags]'
+# MOVING TOWARD:   'exec jupyter lab --config' 
+# Using 'exec' ensures the container catches Slurm/OOD termination signals 
+# immediately, leading to cleaner job exits and faster resource release.
+# -----------------------------------------------------------------------------
+echo "INFO: Launching Jupyter with config file: ${CONF_FILE}"
+exec jupyter lab --config "${CONF_FILE}"

--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -116,40 +116,41 @@ CONF_FILE="${PWD}/jupyter_server_config.py"
 cat <<EOF > "${CONF_FILE}"
 c = get_config()
 
-# --- NETWORK & SECURITY (Universal Auth) ---
+# --- NETWORK & SECURITY ---
 c.ServerApp.ip = '0.0.0.0'
 c.ServerApp.port = ${PORT}
+c.ServerApp.port_retries = 0
 c.ServerApp.base_url = '${BASE_URL}'
+c.ServerApp.PasswordIdentityProvider.hashed_password = '${PASSWORD}'
 c.ServerApp.allow_origin = '*'
 c.ServerApp.disable_check_xsrf = True
 c.ServerApp.open_browser = False
+c.WebPDFExporter.disable_sandbox = True
 
-# Fallback authentication for older notebook shims
-c.NotebookApp.password = '${PASSWORD}' 
-c.ServerApp.password = '${PASSWORD}'
-c.ServerApp.PasswordIdentityProvider.hashed_password = '${PASSWORD}'
+# --- UI & PERFORMANCE OPTIMIZATION (Jupyter Server 2.x Syntax) ---
 
-# --- UI & PERFORMANCE OPTIMIZATION ---
+# A. BACKEND: Explicitly disable server-side extensions
+# We use the full extension name as seen in your logs
+c.ServerApp.jpserver_extensions = {
+    'jupyterlab_git': False,
+    'nbgitpuller': False,
+    'dask_labextension': False,
+    'jupyter_server_xarray_leaflet': False,
+    'panel.io.jupyter_server_extension': False
+}
 
-# A. BACKEND: Disable via the extension manager directly
-c.ExtensionApp.blocked_extensions = [
-    'jupyterlab_git',
-    'dask_labextension',
-    'nbgitpuller',
-    'jupyter_server_xarray_leaflet',
-    'panel.io.jupyter_server_extension'
-]
-
-# B. FRONTEND: Disable UI components
-# Using both LabConfig and LabApp to cover all version bases
-c.LabConfig.disabled_extensions = [
-    '@jupyterlab/extensionmanager-extension',
+# B. FRONTEND: Block the icons and UI components from loading
+# In Server 2.x, LabApp settings are often shimmed through LabServerApp
+c.LabServerApp.blocked_extensions = [
     '@jupyterlab/git',
     '@jupyterlab/github',
-    'dask-labextension'
+    'dask-labextension',
+    'jupyterlab-code-formatter',
+    'jupyter-leaflet'
 ]
-c.LabApp.disabled_extensions = c.LabConfig.disabled_extensions
 
+# Disable the extension manager to stop the startup CPU spike
+c.LabApp.manager_config = {'allowed_extensions': []}
 EOF
 
 echo "INFO: Launching Jupyter with config file: ${CONF_FILE}"

--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -1,116 +1,54 @@
-# !/bin/bash
+#!/bin/bash
 
-# # Run pyppeteer install to fix issue with exporting to pdf
-# # pyppeteer-install
+# Run pyppeteer install to fix issue with exporting to pdf
+# pyppeteer-install
 
-# # -------------------------------------------------------------------------
-# # OPTIONAL: DISABLE HEAVY EXTENSIONS [DEACTIVATED]
-# # -------------------------------------------------------------------------
-# # CONTEXT:
-# # The Jupyter Extension Manager attempts to fetch updates from the internet 
-# # every time the notebook starts. This consumes significant CPU cycles (100% core usage)
-# # for 2-4 seconds during startup.
-# #
-# # HOW TO ENABLE:
-# # Uncomment the line below. This is recommended if running on small nodes 
-# # (e.g., 1-2 CPUs) to prevent startup crashes or sluggishness.
-# # -------------------------------------------------------------------------
-# # DISABLE_FLAGS=""
-# # # DISABLE_FLAGS="--LabApp.disabled_extensions='@jupyterlab/extensionmanager-extension'"
+# -------------------------------------------------------------------------
+# OPTIONAL: DISABLE HEAVY EXTENSIONS [DEACTIVATED]
+# -------------------------------------------------------------------------
+# CONTEXT:
+# The Jupyter Extension Manager attempts to fetch updates from the internet 
+# every time the notebook starts. This consumes significant CPU cycles (100% core usage)
+# for 2-4 seconds during startup.
+#
+# HOW TO ENABLE:
+# Uncomment the line below. This is recommended if running on small nodes 
+# (e.g., 1-2 CPUs) to prevent startup crashes or sluggishness.
+# -------------------------------------------------------------------------
+# DISABLE_FLAGS=""
+# # DISABLE_FLAGS="--LabApp.disabled_extensions='@jupyterlab/extensionmanager-extension'"
 
-# # jupyter lab \
-# #            --ip='0.0.0.0' \
-# #            --port="${MY_JUP_PORT}" \
-# #            --port-retries=0 \
-# #            --ServerApp.PasswordIdentityProvider.hashed_password="${MY_JUP_PASSWD}" \
-# #            --ServerApp.base_url="${MY_JUP_BASEURL}" \
-# #            --no-browser \
-# #            --ServerApp.allow_origin='*' \
-# #            --ServerApp.disable_check_xsrf=True \
-# #            --WebPDFExporter.disable_sandbox=True
-
-
-# # -------------------------------------------------------------------------
-# # OPTIMIZED LAUNCH SCRIPT WITH SCRATCH/LUSTRE REDIRECTION
-# # -------------------------------------------------------------------------
-# # Optimized for Luster and High-Concurrency I/O Classes.
-
-# # --- 1. SET UP PARAMETERS ---
-# PORT="${MY_JUP_PORT:-8888}"
-# BASE_URL="${MY_JUP_BASEURL:-/}"
-# PASSWORD="${MY_JUP_PASSWD}"
+# jupyter lab \
+#            --ip='0.0.0.0' \
+#            --port="${MY_JUP_PORT}" \
+#            --port-retries=0 \
+#            --ServerApp.PasswordIdentityProvider.hashed_password="${MY_JUP_PASSWD}" \
+#            --ServerApp.base_url="${MY_JUP_BASEURL}" \
+#            --no-browser \
+#            --ServerApp.allow_origin='*' \
+#            --ServerApp.disable_check_xsrf=True \
+#            --WebPDFExporter.disable_sandbox=True
 
 
-# # --- 2. GENERATE RUNTIME CONFIGURATION FILE ---
-# # MOVING AWAY FROM: Passing raw CLI flags (e.g., --ip, --port) which may be prone 
-# #                  to shell-escaping errors and cause "Missing Extension" popups.
-# #
-# # MOVING TOWARD:   A generated Python config file to 
-# #                  simultaneously disable Backend and Frontend components to 
-# #                  fix UI sluggishness and icon "lag."
-# # -----------------------------------------------------------------------------
-# CONF_FILE="${PWD}/jupyter_server_config.py"
+# -------------------------------------------------------------------------
+# OPTIMIZED LAUNCH SCRIPT WITH SCRATCH/LUSTRE REDIRECTION
+# -------------------------------------------------------------------------
+# Optimized for Luster and High-Concurrency I/O Classes.
 
-# cat <<EOF > "${CONF_FILE}"
-# c = get_config()
-
-# # --- NETWORK & SECURITY ---
-# c.ServerApp.ip = '0.0.0.0'
-# c.ServerApp.port = ${PORT}
-# c.ServerApp.port_retries = 0
-# c.ServerApp.base_url = '${BASE_URL}'
-# c.ServerApp.PasswordIdentityProvider.hashed_password = '${PASSWORD}'
-# c.ServerApp.allow_origin = '*'
-# c.ServerApp.disable_check_xsrf = True
-# c.ServerApp.open_browser = False
-# c.WebPDFExporter.disable_sandbox = True
-
-# # --- UI & PERFORMANCE OPTIMIZATION (THE "ICON & POPUP" FIX) ---
-# # MOVING AWAY FROM: Default loading of all sidebar extensions.
-# # MOVING TOWARD:   Explicitly disabling high-I/O extensions. This prevents the 
-# #                  browser from "searching" for icons and status updates on 
-# #                  slow storage, which fixes the "Sluggish Icon" effect.
-
-# # A. BACKEND: Stop the Python server from loading these plugins (Saves RAM/CPU)
-# c.ServerApp.jpserver_extensions = {
-#     'dask_labextension': False,             # Constantly polls cluster status
-#     'jupyter_server_xarray_leaflet': False, # Heavy GIS metadata calls
-#     'jupyterlab_git': False,                # Crawls file tree for .git folders
-#     'nbgitpuller': False,                   # External sync service
-#     'panel.io.jupyter_server_extension': False # Dask-related, heavy JS load
-# }
-
-# # B. FRONTEND: Stop the Browser from requesting these icons (Fixes rendering lag)
-# # By matching this list with the backend above, we prevent "Extension Missing" popups.
-# c.LabConfig.disabled_extensions = [
-#     '@jupyterlab/extensionmanager-extension', # Goal to prevents CPU spike on startup
-#     '@jupyterlab/git',                        # Removes sidebar Git icon, git can be handled via terminal
-#     '@jupyterlab/github',                     # Removes sidebar GitHub icon, git can be handled via terminal
-#     '@jupyterlab/google-drive',                # Removes sidebar Drive icon, prevents heavy Google API calls
-#     'dask-labextension',                      # Removes sidebar Dask icon, Dask can still be used via terminal or code
-#     'jupyter-leaflet'                         # Prevents heavy GIS JS load, static maps can still be used in notebooks
-# ]
-# EOF
-
-
-# # --- 3. LAUNCH JUPYTER ---
-# # MOVING AWAY FROM: 'jupyter lab [flags]'
-# # MOVING TOWARD:   'exec jupyter lab --config' 
-# # Using 'exec' ensures the container catches Slurm/OOD termination signals 
-# # immediately, leading to cleaner job exits and faster resource release.
-# # -----------------------------------------------------------------------------
-# echo "INFO: Launching Jupyter with config file: ${CONF_FILE}"
-# exec jupyter lab --config "${CONF_FILE}"
-
-
-# =============================================================================
-# JUPYTER LAUNCH SCRIPT (Universal Performance & Auth Fix)
-# =============================================================================
-
+# --- 1. SET UP PARAMETERS ---
 PORT="${MY_JUP_PORT:-8888}"
 BASE_URL="${MY_JUP_BASEURL:-/}"
 PASSWORD="${MY_JUP_PASSWD}"
 
+
+# --- 2. GENERATE RUNTIME CONFIGURATION FILE ---
+# MOVING AWAY FROM: Passing raw CLI flags (e.g., --ip, --port) which may be prone 
+#                  to shell-escaping errors and cause "Missing Extension" popups.
+#
+# MOVING TOWARD:   A generated Python config file to 
+#                  simultaneously disable Backend and Frontend components to 
+#                  fix UI sluggishness and icon "lag."
+# -----------------------------------------------------------------------------
 CONF_FILE="${PWD}/jupyter_server_config.py"
 
 cat <<EOF > "${CONF_FILE}"
@@ -127,31 +65,39 @@ c.ServerApp.disable_check_xsrf = True
 c.ServerApp.open_browser = False
 c.WebPDFExporter.disable_sandbox = True
 
-# --- UI & PERFORMANCE OPTIMIZATION (Jupyter Server 2.x Syntax) ---
+# --- UI & PERFORMANCE OPTIMIZATION (THE "ICON & POPUP" FIX) ---
+# MOVING AWAY FROM: Default loading of all sidebar extensions.
+# MOVING TOWARD:   Explicitly disabling high-I/O extensions. This prevents the 
+#                  browser from "searching" for icons and status updates on 
+#                  slow storage, which fixes the "Sluggish Icon" effect.
 
-# A. BACKEND: Explicitly disable server-side extensions
-# We use the full extension name as seen in your logs
+# A. BACKEND: Stop the Python server from loading these plugins (Saves RAM/CPU)
 c.ServerApp.jpserver_extensions = {
-    'jupyterlab_git': False,
-    'nbgitpuller': False,
-    'dask_labextension': False,
-    'jupyter_server_xarray_leaflet': False,
-    'panel.io.jupyter_server_extension': False
+    'dask_labextension': False,             # Constantly polls cluster status
+    'jupyter_server_xarray_leaflet': False, # Heavy GIS metadata calls
+    'jupyterlab_git': False,                # Crawls file tree for .git folders
+    'nbgitpuller': False,                   # External sync service
+    'panel.io.jupyter_server_extension': False # Dask-related, heavy JS load
 }
 
-# B. FRONTEND: Block the icons and UI components from loading
-# In Server 2.x, LabApp settings are often shimmed through LabServerApp
-c.LabServerApp.blocked_extensions = [
-    '@jupyterlab/git',
-    '@jupyterlab/github',
-    'dask-labextension',
-    'jupyterlab-code-formatter',
-    'jupyter-leaflet'
+# B. FRONTEND: Stop the Browser from requesting these icons (Fixes rendering lag)
+# By matching this list with the backend above, we prevent "Extension Missing" popups.
+c.LabConfig.disabled_extensions = [
+    '@jupyterlab/extensionmanager-extension', # Goal to prevents CPU spike on startup
+    '@jupyterlab/git',                        # Removes sidebar Git icon, git can be handled via terminal
+    '@jupyterlab/github',                     # Removes sidebar GitHub icon, git can be handled via terminal
+    '@jupyterlab/google-drive',                # Removes sidebar Drive icon, prevents heavy Google API calls
+    'dask-labextension',                      # Removes sidebar Dask icon, Dask can still be used via terminal or code
+    'jupyter-leaflet'                         # Prevents heavy GIS JS load, static maps can still be used in notebooks
 ]
-
-# Disable the extension manager to stop the startup CPU spike
-c.LabApp.manager_config = {'allowed_extensions': []}
 EOF
 
+
+# --- 3. LAUNCH JUPYTER ---
+# MOVING AWAY FROM: 'jupyter lab [flags]'
+# MOVING TOWARD:   'exec jupyter lab --config' 
+# Using 'exec' ensures the container catches Slurm/OOD termination signals 
+# immediately, leading to cleaner job exits and faster resource release.
+# -----------------------------------------------------------------------------
 echo "INFO: Launching Jupyter with config file: ${CONF_FILE}"
 exec jupyter lab --config "${CONF_FILE}"

--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -3,20 +3,17 @@
 # Run pyppeteer install to fix issue with exporting to pdf
 # pyppeteer-install
 
+# This scriptp was refined with the help of Gemini 3 Pro and Claude 4.5 Sonnet AI Models
+
 # -------------------------------------------------------------------------
-# OPTIONAL: DISABLE HEAVY EXTENSIONS [DEACTIVATED]
+# OPTIONAL: DISABLE HEAVY EXTENSIONS (LEGACY CLI METHOD – NOW REPLACED)
 # -------------------------------------------------------------------------
-# CONTEXT:
-# The Jupyter Extension Manager attempts to fetch updates from the internet 
-# every time the notebook starts. This consumes significant CPU cycles (100% core usage)
-# for 2-4 seconds during startup.
-#
-# HOW TO ENABLE:
-# Uncomment the line below. This is recommended if running on small nodes 
-# (e.g., 1-2 CPUs) to prevent startup crashes or sluggishness.
+# The old approach used CLI flags (DISABLE_FLAGS) to disable extensions.
+# We now prefer config files (page_config.json + jupyter_server_config.py)
+# to control both frontend and backend extensions.
 # -------------------------------------------------------------------------
 # DISABLE_FLAGS=""
-# # DISABLE_FLAGS="--LabApp.disabled_extensions='@jupyterlab/extensionmanager-extension'"
+# DISABLE_FLAGS="--LabApp.disabled_extensions='@jupyterlab/extensionmanager-extension'"
 
 # jupyter lab \
 #            --ip='0.0.0.0' \
@@ -29,38 +26,29 @@
 #            --ServerApp.disable_check_xsrf=True \
 #            --WebPDFExporter.disable_sandbox=True
 
-
 # -------------------------------------------------------------------------
-# OPTIMIZED LAUNCH SCRIPT WITH SCRATCH/LUSTRE REDIRECTION
+# OPTIMIZED LAUNCH SCRIPT USING GENERATED CONFIG
 # -------------------------------------------------------------------------
-# Optimized for Luster and High-Concurrency I/O Classes.
 
-# --- 1. SET UP PARAMETERS ---
+# Basic server parameters from the OOD/apptainer environment
 PORT="${MY_JUP_PORT:-8888}"
 BASE_URL="${MY_JUP_BASEURL:-/}"
 PASSWORD="${MY_JUP_PASSWD}"
 
-
-# --- 2. FRONTEND CONFIG: disable Lab extensions via page_config.json ---
-
-
-
-# --- 3. GENERATE RUNTIME CONFIGURATION FILE ---
-# MOVING AWAY FROM: Passing raw CLI flags (e.g., --ip, --port) which may be prone 
-#                  to shell-escaping errors and cause "Missing Extension" popups.
+# -------------------------------------------------------------------------
+# 1. FRONTEND: disable heavy JupyterLab extensions via page_config.json
 #
-# MOVING TOWARD:   A generated Python config file to 
-#                  simultaneously disable Backend and Frontend components to 
-#                  fix UI sluggishness and icon "lag."
-# -----------------------------------------------------------------------------
-# Creat e Jupyter Lab frontend config directory if it doesn't exist
+# This controls the browser-side extensions (sidebars, icons, menus).
+# Disabling high-I/O / external service integrations here reduces the
+# number of small asset loads and API calls during startup.
+# -------------------------------------------------------------------------
 LABCONFIG_DIR="${HOME}/.jupyter/labconfig"
 mkdir -p "${LABCONFIG_DIR}"
 
 cat > "${LABCONFIG_DIR}/page_config.json" <<'EOF'
 {
   "disabledExtensions": {
-    "@jupyterlab/extensionmanager-extension": true, 
+    "@jupyterlab/extensionmanager-extension": true,
     "@jupyterlab/git": true,
     "@jupyterlab/github": true,
     "@jupyterlab/google-drive": true,
@@ -72,7 +60,13 @@ cat > "${LABCONFIG_DIR}/page_config.json" <<'EOF'
 }
 EOF
 
-# Create a temporary Jupyter config file for the server settings
+# -------------------------------------------------------------------------
+# 2. BACKEND: generate a temporary jupyter_server_config.py
+#
+# This replaces long CLI flag lists with a single config file that:
+# - Sets the usual ServerApp network/security options.
+# - Disables selected jpserver extensions that do heavy polling or I/O.
+# -------------------------------------------------------------------------
 CONF_FILE="${PWD}/jupyter_server_config.py"
 
 cat <<EOF > "${CONF_FILE}"
@@ -89,28 +83,23 @@ c.ServerApp.disable_check_xsrf = True
 c.ServerApp.open_browser = False
 c.WebPDFExporter.disable_sandbox = True
 
-# --- UI & PERFORMANCE OPTIMIZATION (THE "ICON & POPUP" FIX) ---
-# MOVING AWAY FROM: Default loading of all sidebar extensions.
-# MOVING TOWARD:   Explicitly disabling high-I/O extensions. This prevents the 
-#                  browser from "searching" for icons and status updates on 
-#                  slow storage, which fixes the "Sluggish Icon" effect.
-
-# A. BACKEND: Stop the Python server from loading these plugins (Saves RAM/CPU)
+# --- UI & PERFORMANCE OPTIMIZATIONS ---
+# Disable backend extensions that cause extra polling or metadata scans.
 c.ServerApp.jpserver_extensions = {
-    'dask_labextension': False,             # Constantly polls cluster status
-    'jupyter_server_xarray_leaflet': False, # Heavy GIS metadata calls
-    'jupyterlab_git': False,                # Crawls file tree for .git folders
-    'nbgitpuller': False,                   # External sync service
-    'panel.io.jupyter_server_extension': False # Dask-related, heavy JS load
+    'dask_labextension': False,
+    'jupyter_server_xarray_leaflet': False,
+    'jupyterlab_git': False,
+    'nbgitpuller': False,
+    'panel.io.jupyter_server_extension': False
 }
 EOF
 
-
-# --- 4. LAUNCH JUPYTER ---
-# MOVING AWAY FROM: 'jupyter lab [flags]'
-# MOVING TOWARD:   'exec jupyter lab --config' 
-# Using 'exec' ensures the container catches Slurm/OOD termination signals 
-# immediately, leading to cleaner job exits and faster resource release.
-# -----------------------------------------------------------------------------
-echo "INFO: Launching Jupyter with config file: ${CONF_FILE}"
+# -------------------------------------------------------------------------
+# 3. LAUNCH JUPYTERLAB USING THE CONFIG FILE
+#
+# Using 'exec' ensures the Jupyter process becomes PID 1 in the container
+# so Slurm/OOD signals (TERM, INT) are delivered cleanly and jobs exit
+# promptly when cancelled.
+# -------------------------------------------------------------------------
+echo "INFO: Launching JupyterLab with config file: ${CONF_FILE}"
 exec jupyter lab --config "${CONF_FILE}"

--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -41,7 +41,29 @@ BASE_URL="${MY_JUP_BASEURL:-/}"
 PASSWORD="${MY_JUP_PASSWD}"
 
 
-# --- 2. GENERATE RUNTIME CONFIGURATION FILE ---
+# --- 2. FRONTEND CONFIG: disable Lab extensions via page_config.json ---
+# FIX: Separated the variable definition from the mkdir command
+LABCONFIG_DIR="${HOME}/.jupyter/labconfig"
+mkdir -p "${LABCONFIG_DIR}"
+
+# We use quoted 'EOF' to prevent any accidental shell expansion in the JSON
+cat > "${LABCONFIG_DIR}/page_config.json" <<'EOF'
+{
+  "disabledExtensions": {
+    "@jupyterlab/extensionmanager-extension": true, 
+    "@jupyterlab/git": true,
+    "@jupyterlab/github": true,
+    "@jupyterlab/google-drive": true,
+    "dask-labextension": true,
+    "jupyter-leaflet": true,
+    "jupyterlab-code-formatter": true,
+    "nbdime-jupyterlab": true
+  }
+}
+EOF
+
+
+# --- 3. GENERATE RUNTIME CONFIGURATION FILE ---
 # MOVING AWAY FROM: Passing raw CLI flags (e.g., --ip, --port) which may be prone 
 #                  to shell-escaping errors and cause "Missing Extension" popups.
 #
@@ -93,7 +115,7 @@ c.LabConfig.disabled_extensions = [
 EOF
 
 
-# --- 3. LAUNCH JUPYTER ---
+# --- 4. LAUNCH JUPYTER ---
 # MOVING AWAY FROM: 'jupyter lab [flags]'
 # MOVING TOWARD:   'exec jupyter lab --config' 
 # Using 'exec' ensures the container catches Slurm/OOD termination signals 

--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -1,103 +1,156 @@
-#!/bin/bash
+# !/bin/bash
 
-# Run pyppeteer install to fix issue with exporting to pdf
-# pyppeteer-install
+# # Run pyppeteer install to fix issue with exporting to pdf
+# # pyppeteer-install
 
-# -------------------------------------------------------------------------
-# OPTIONAL: DISABLE HEAVY EXTENSIONS [DEACTIVATED]
-# -------------------------------------------------------------------------
-# CONTEXT:
-# The Jupyter Extension Manager attempts to fetch updates from the internet 
-# every time the notebook starts. This consumes significant CPU cycles (100% core usage)
-# for 2-4 seconds during startup.
-#
-# HOW TO ENABLE:
-# Uncomment the line below. This is recommended if running on small nodes 
-# (e.g., 1-2 CPUs) to prevent startup crashes or sluggishness.
-# -------------------------------------------------------------------------
-# DISABLE_FLAGS=""
-# # DISABLE_FLAGS="--LabApp.disabled_extensions='@jupyterlab/extensionmanager-extension'"
+# # -------------------------------------------------------------------------
+# # OPTIONAL: DISABLE HEAVY EXTENSIONS [DEACTIVATED]
+# # -------------------------------------------------------------------------
+# # CONTEXT:
+# # The Jupyter Extension Manager attempts to fetch updates from the internet 
+# # every time the notebook starts. This consumes significant CPU cycles (100% core usage)
+# # for 2-4 seconds during startup.
+# #
+# # HOW TO ENABLE:
+# # Uncomment the line below. This is recommended if running on small nodes 
+# # (e.g., 1-2 CPUs) to prevent startup crashes or sluggishness.
+# # -------------------------------------------------------------------------
+# # DISABLE_FLAGS=""
+# # # DISABLE_FLAGS="--LabApp.disabled_extensions='@jupyterlab/extensionmanager-extension'"
 
-# jupyter lab \
-#            --ip='0.0.0.0' \
-#            --port="${MY_JUP_PORT}" \
-#            --port-retries=0 \
-#            --ServerApp.PasswordIdentityProvider.hashed_password="${MY_JUP_PASSWD}" \
-#            --ServerApp.base_url="${MY_JUP_BASEURL}" \
-#            --no-browser \
-#            --ServerApp.allow_origin='*' \
-#            --ServerApp.disable_check_xsrf=True \
-#            --WebPDFExporter.disable_sandbox=True
+# # jupyter lab \
+# #            --ip='0.0.0.0' \
+# #            --port="${MY_JUP_PORT}" \
+# #            --port-retries=0 \
+# #            --ServerApp.PasswordIdentityProvider.hashed_password="${MY_JUP_PASSWD}" \
+# #            --ServerApp.base_url="${MY_JUP_BASEURL}" \
+# #            --no-browser \
+# #            --ServerApp.allow_origin='*' \
+# #            --ServerApp.disable_check_xsrf=True \
+# #            --WebPDFExporter.disable_sandbox=True
 
 
-# -------------------------------------------------------------------------
-# OPTIMIZED LAUNCH SCRIPT WITH SCRATCH/LUSTRE REDIRECTION
-# -------------------------------------------------------------------------
-# Optimized for Luster and High-Concurrency I/O Classes.
+# # -------------------------------------------------------------------------
+# # OPTIMIZED LAUNCH SCRIPT WITH SCRATCH/LUSTRE REDIRECTION
+# # -------------------------------------------------------------------------
+# # Optimized for Luster and High-Concurrency I/O Classes.
 
-# --- 1. SET UP PARAMETERS ---
+# # --- 1. SET UP PARAMETERS ---
+# PORT="${MY_JUP_PORT:-8888}"
+# BASE_URL="${MY_JUP_BASEURL:-/}"
+# PASSWORD="${MY_JUP_PASSWD}"
+
+
+# # --- 2. GENERATE RUNTIME CONFIGURATION FILE ---
+# # MOVING AWAY FROM: Passing raw CLI flags (e.g., --ip, --port) which may be prone 
+# #                  to shell-escaping errors and cause "Missing Extension" popups.
+# #
+# # MOVING TOWARD:   A generated Python config file to 
+# #                  simultaneously disable Backend and Frontend components to 
+# #                  fix UI sluggishness and icon "lag."
+# # -----------------------------------------------------------------------------
+# CONF_FILE="${PWD}/jupyter_server_config.py"
+
+# cat <<EOF > "${CONF_FILE}"
+# c = get_config()
+
+# # --- NETWORK & SECURITY ---
+# c.ServerApp.ip = '0.0.0.0'
+# c.ServerApp.port = ${PORT}
+# c.ServerApp.port_retries = 0
+# c.ServerApp.base_url = '${BASE_URL}'
+# c.ServerApp.PasswordIdentityProvider.hashed_password = '${PASSWORD}'
+# c.ServerApp.allow_origin = '*'
+# c.ServerApp.disable_check_xsrf = True
+# c.ServerApp.open_browser = False
+# c.WebPDFExporter.disable_sandbox = True
+
+# # --- UI & PERFORMANCE OPTIMIZATION (THE "ICON & POPUP" FIX) ---
+# # MOVING AWAY FROM: Default loading of all sidebar extensions.
+# # MOVING TOWARD:   Explicitly disabling high-I/O extensions. This prevents the 
+# #                  browser from "searching" for icons and status updates on 
+# #                  slow storage, which fixes the "Sluggish Icon" effect.
+
+# # A. BACKEND: Stop the Python server from loading these plugins (Saves RAM/CPU)
+# c.ServerApp.jpserver_extensions = {
+#     'dask_labextension': False,             # Constantly polls cluster status
+#     'jupyter_server_xarray_leaflet': False, # Heavy GIS metadata calls
+#     'jupyterlab_git': False,                # Crawls file tree for .git folders
+#     'nbgitpuller': False,                   # External sync service
+#     'panel.io.jupyter_server_extension': False # Dask-related, heavy JS load
+# }
+
+# # B. FRONTEND: Stop the Browser from requesting these icons (Fixes rendering lag)
+# # By matching this list with the backend above, we prevent "Extension Missing" popups.
+# c.LabConfig.disabled_extensions = [
+#     '@jupyterlab/extensionmanager-extension', # Goal to prevents CPU spike on startup
+#     '@jupyterlab/git',                        # Removes sidebar Git icon, git can be handled via terminal
+#     '@jupyterlab/github',                     # Removes sidebar GitHub icon, git can be handled via terminal
+#     '@jupyterlab/google-drive',                # Removes sidebar Drive icon, prevents heavy Google API calls
+#     'dask-labextension',                      # Removes sidebar Dask icon, Dask can still be used via terminal or code
+#     'jupyter-leaflet'                         # Prevents heavy GIS JS load, static maps can still be used in notebooks
+# ]
+# EOF
+
+
+# # --- 3. LAUNCH JUPYTER ---
+# # MOVING AWAY FROM: 'jupyter lab [flags]'
+# # MOVING TOWARD:   'exec jupyter lab --config' 
+# # Using 'exec' ensures the container catches Slurm/OOD termination signals 
+# # immediately, leading to cleaner job exits and faster resource release.
+# # -----------------------------------------------------------------------------
+# echo "INFO: Launching Jupyter with config file: ${CONF_FILE}"
+# exec jupyter lab --config "${CONF_FILE}"
+
+
+# =============================================================================
+# JUPYTER LAUNCH SCRIPT (Universal Performance & Auth Fix)
+# =============================================================================
+
 PORT="${MY_JUP_PORT:-8888}"
 BASE_URL="${MY_JUP_BASEURL:-/}"
 PASSWORD="${MY_JUP_PASSWD}"
 
-
-# --- 2. GENERATE RUNTIME CONFIGURATION FILE ---
-# MOVING AWAY FROM: Passing raw CLI flags (e.g., --ip, --port) which may be prone 
-#                  to shell-escaping errors and cause "Missing Extension" popups.
-#
-# MOVING TOWARD:   A generated Python config file to 
-#                  simultaneously disable Backend and Frontend components to 
-#                  fix UI sluggishness and icon "lag."
-# -----------------------------------------------------------------------------
 CONF_FILE="${PWD}/jupyter_server_config.py"
 
 cat <<EOF > "${CONF_FILE}"
 c = get_config()
 
-# --- NETWORK & SECURITY ---
+# --- NETWORK & SECURITY (Universal Auth) ---
 c.ServerApp.ip = '0.0.0.0'
 c.ServerApp.port = ${PORT}
-c.ServerApp.port_retries = 0
 c.ServerApp.base_url = '${BASE_URL}'
-c.ServerApp.PasswordIdentityProvider.hashed_password = '${PASSWORD}'
 c.ServerApp.allow_origin = '*'
 c.ServerApp.disable_check_xsrf = True
 c.ServerApp.open_browser = False
-c.WebPDFExporter.disable_sandbox = True
 
-# --- UI & PERFORMANCE OPTIMIZATION (THE "ICON & POPUP" FIX) ---
-# MOVING AWAY FROM: Default loading of all sidebar extensions.
-# MOVING TOWARD:   Explicitly disabling high-I/O extensions. This prevents the 
-#                  browser from "searching" for icons and status updates on 
-#                  slow storage, which fixes the "Sluggish Icon" effect.
+# Fallback authentication for older notebook shims
+c.NotebookApp.password = '${PASSWORD}' 
+c.ServerApp.password = '${PASSWORD}'
+c.ServerApp.PasswordIdentityProvider.hashed_password = '${PASSWORD}'
 
-# A. BACKEND: Stop the Python server from loading these plugins (Saves RAM/CPU)
-c.ServerApp.jpserver_extensions = {
-    'dask_labextension': False,             # Constantly polls cluster status
-    'jupyter_server_xarray_leaflet': False, # Heavy GIS metadata calls
-    'jupyterlab_git': False,                # Crawls file tree for .git folders
-    'nbgitpuller': False,                   # External sync service
-    'panel.io.jupyter_server_extension': False # Dask-related, heavy JS load
-}
+# --- UI & PERFORMANCE OPTIMIZATION ---
 
-# B. FRONTEND: Stop the Browser from requesting these icons (Fixes rendering lag)
-# By matching this list with the backend above, we prevent "Extension Missing" popups.
-c.LabConfig.disabled_extensions = [
-    '@jupyterlab/extensionmanager-extension', # Goal to prevents CPU spike on startup
-    '@jupyterlab/git',                        # Removes sidebar Git icon, git can be handled via terminal
-    '@jupyterlab/github',                     # Removes sidebar GitHub icon, git can be handled via terminal
-    '@jupyterlab/google-drive',                # Removes sidebar Drive icon, prevents heavy Google API calls
-    'dask-labextension',                      # Removes sidebar Dask icon, Dask can still be used via terminal or code
-    'jupyter-leaflet'                         # Prevents heavy GIS JS load, static maps can still be used in notebooks
+# A. BACKEND: Disable via the extension manager directly
+c.ExtensionApp.blocked_extensions = [
+    'jupyterlab_git',
+    'dask_labextension',
+    'nbgitpuller',
+    'jupyter_server_xarray_leaflet',
+    'panel.io.jupyter_server_extension'
 ]
+
+# B. FRONTEND: Disable UI components
+# Using both LabConfig and LabApp to cover all version bases
+c.LabConfig.disabled_extensions = [
+    '@jupyterlab/extensionmanager-extension',
+    '@jupyterlab/git',
+    '@jupyterlab/github',
+    'dask-labextension'
+]
+c.LabApp.disabled_extensions = c.LabConfig.disabled_extensions
+
 EOF
 
-
-# --- 3. LAUNCH JUPYTER ---
-# MOVING AWAY FROM: 'jupyter lab [flags]'
-# MOVING TOWARD:   'exec jupyter lab --config' 
-# Using 'exec' ensures the container catches Slurm/OOD termination signals 
-# immediately, leading to cleaner job exits and faster resource release.
-# -----------------------------------------------------------------------------
 echo "INFO: Launching Jupyter with config file: ${CONF_FILE}"
 exec jupyter lab --config "${CONF_FILE}"

--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -18,86 +18,86 @@
 # DISABLE_FLAGS=""
 # # DISABLE_FLAGS="--LabApp.disabled_extensions='@jupyterlab/extensionmanager-extension'"
 
-jupyter lab \
-           --ip='0.0.0.0' \
-           --port="${MY_JUP_PORT}" \
-           --port-retries=0 \
-           --ServerApp.PasswordIdentityProvider.hashed_password="${MY_JUP_PASSWD}" \
-           --ServerApp.base_url="${MY_JUP_BASEURL}" \
-           --no-browser \
-           --ServerApp.allow_origin='*' \
-           --ServerApp.disable_check_xsrf=True \
-           --WebPDFExporter.disable_sandbox=True
+# jupyter lab \
+#            --ip='0.0.0.0' \
+#            --port="${MY_JUP_PORT}" \
+#            --port-retries=0 \
+#            --ServerApp.PasswordIdentityProvider.hashed_password="${MY_JUP_PASSWD}" \
+#            --ServerApp.base_url="${MY_JUP_BASEURL}" \
+#            --no-browser \
+#            --ServerApp.allow_origin='*' \
+#            --ServerApp.disable_check_xsrf=True \
+#            --WebPDFExporter.disable_sandbox=True
 
 
-# # -------------------------------------------------------------------------
-# # OPTIMIZED LAUNCH SCRIPT WITH SCRATCH/LUSTRE REDIRECTION
-# # -------------------------------------------------------------------------
-# # Optimized for Luster and High-Concurrency I/O Classes.
+# -------------------------------------------------------------------------
+# OPTIMIZED LAUNCH SCRIPT WITH SCRATCH/LUSTRE REDIRECTION
+# -------------------------------------------------------------------------
+# Optimized for Luster and High-Concurrency I/O Classes.
 
-# # --- 1. SET UP PARAMETERS ---
-# PORT="${MY_JUP_PORT:-8888}"
-# BASE_URL="${MY_JUP_BASEURL:-/}"
-# PASSWORD="${MY_JUP_PASSWD}"
-
-
-# # --- 2. GENERATE RUNTIME CONFIGURATION FILE ---
-# # MOVING AWAY FROM: Passing raw CLI flags (e.g., --ip, --port) which may be prone 
-# #                  to shell-escaping errors and cause "Missing Extension" popups.
-# #
-# # MOVING TOWARD:   A generated Python config file to 
-# #                  simultaneously disable Backend and Frontend components to 
-# #                  fix UI sluggishness and icon "lag."
-# # -----------------------------------------------------------------------------
-# CONF_FILE="${PWD}/jupyter_server_config.py"
-
-# cat <<EOF > "${CONF_FILE}"
-# c = get_config()
-
-# # --- NETWORK & SECURITY ---
-# c.ServerApp.ip = '0.0.0.0'
-# c.ServerApp.port = ${PORT}
-# c.ServerApp.port_retries = 0
-# c.ServerApp.base_url = '${BASE_URL}'
-# c.ServerApp.PasswordIdentityProvider.hashed_password = '${PASSWORD}'
-# c.ServerApp.allow_origin = '*'
-# c.ServerApp.disable_check_xsrf = True
-# c.ServerApp.open_browser = False
-# c.WebPDFExporter.disable_sandbox = True
-
-# # --- UI & PERFORMANCE OPTIMIZATION (THE "ICON & POPUP" FIX) ---
-# # MOVING AWAY FROM: Default loading of all sidebar extensions.
-# # MOVING TOWARD:   Explicitly disabling high-I/O extensions. This prevents the 
-# #                  browser from "searching" for icons and status updates on 
-# #                  slow storage, which fixes the "Sluggish Icon" effect.
-
-# # A. BACKEND: Stop the Python server from loading these plugins (Saves RAM/CPU)
-# c.ServerApp.jpserver_extensions = {
-#     'dask_labextension': False,             # Constantly polls cluster status
-#     'jupyter_server_xarray_leaflet': False, # Heavy GIS metadata calls
-#     'jupyterlab_git': False,                # Crawls file tree for .git folders
-#     'nbgitpuller': False,                   # External sync service
-#     'panel.io.jupyter_server_extension': False # Dask-related, heavy JS load
-# }
-
-# # B. FRONTEND: Stop the Browser from requesting these icons (Fixes rendering lag)
-# # By matching this list with the backend above, we prevent "Extension Missing" popups.
-# c.LabConfig.disabled_extensions = [
-#     '@jupyterlab/extensionmanager-extension', # Goal to prevents CPU spike on startup
-#     '@jupyterlab/git',                        # Removes sidebar Git icon, git can be handled via terminal
-#     '@jupyterlab/github',                     # Removes sidebar GitHub icon, git can be handled via terminal
-#     '@jupyterlab/google-drive',                # Removes sidebar Drive icon, prevents heavy Google API calls
-#     'dask-labextension',                      # Removes sidebar Dask icon, Dask can still be used via terminal or code
-#     'jupyter-leaflet'                         # Prevents heavy GIS JS load, static maps can still be used in notebooks
-# ]
-# EOF
+# --- 1. SET UP PARAMETERS ---
+PORT="${MY_JUP_PORT:-8888}"
+BASE_URL="${MY_JUP_BASEURL:-/}"
+PASSWORD="${MY_JUP_PASSWD}"
 
 
-# # --- 3. LAUNCH JUPYTER ---
-# # MOVING AWAY FROM: 'jupyter lab [flags]'
-# # MOVING TOWARD:   'exec jupyter lab --config' 
-# # Using 'exec' ensures the container catches Slurm/OOD termination signals 
-# # immediately, leading to cleaner job exits and faster resource release.
-# # -----------------------------------------------------------------------------
-# echo "INFO: Launching Jupyter with config file: ${CONF_FILE}"
-# exec jupyter lab --config "${CONF_FILE}"
+# --- 2. GENERATE RUNTIME CONFIGURATION FILE ---
+# MOVING AWAY FROM: Passing raw CLI flags (e.g., --ip, --port) which may be prone 
+#                  to shell-escaping errors and cause "Missing Extension" popups.
+#
+# MOVING TOWARD:   A generated Python config file to 
+#                  simultaneously disable Backend and Frontend components to 
+#                  fix UI sluggishness and icon "lag."
+# -----------------------------------------------------------------------------
+CONF_FILE="${PWD}/jupyter_server_config.py"
+
+cat <<EOF > "${CONF_FILE}"
+c = get_config()
+
+# --- NETWORK & SECURITY ---
+c.ServerApp.ip = '0.0.0.0'
+c.ServerApp.port = ${PORT}
+c.ServerApp.port_retries = 0
+c.ServerApp.base_url = '${BASE_URL}'
+c.ServerApp.PasswordIdentityProvider.hashed_password = '${PASSWORD}'
+c.ServerApp.allow_origin = '*'
+c.ServerApp.disable_check_xsrf = True
+c.ServerApp.open_browser = False
+c.WebPDFExporter.disable_sandbox = True
+
+# --- UI & PERFORMANCE OPTIMIZATION (THE "ICON & POPUP" FIX) ---
+# MOVING AWAY FROM: Default loading of all sidebar extensions.
+# MOVING TOWARD:   Explicitly disabling high-I/O extensions. This prevents the 
+#                  browser from "searching" for icons and status updates on 
+#                  slow storage, which fixes the "Sluggish Icon" effect.
+
+# A. BACKEND: Stop the Python server from loading these plugins (Saves RAM/CPU)
+c.ServerApp.jpserver_extensions = {
+    'dask_labextension': False,             # Constantly polls cluster status
+    'jupyter_server_xarray_leaflet': False, # Heavy GIS metadata calls
+    'jupyterlab_git': False,                # Crawls file tree for .git folders
+    'nbgitpuller': False,                   # External sync service
+    'panel.io.jupyter_server_extension': False # Dask-related, heavy JS load
+}
+
+# B. FRONTEND: Stop the Browser from requesting these icons (Fixes rendering lag)
+# By matching this list with the backend above, we prevent "Extension Missing" popups.
+c.LabConfig.disabled_extensions = [
+    '@jupyterlab/extensionmanager-extension', # Goal to prevents CPU spike on startup
+    '@jupyterlab/git',                        # Removes sidebar Git icon, git can be handled via terminal
+    '@jupyterlab/github',                     # Removes sidebar GitHub icon, git can be handled via terminal
+    '@jupyterlab/google-drive',                # Removes sidebar Drive icon, prevents heavy Google API calls
+    'dask-labextension',                      # Removes sidebar Dask icon, Dask can still be used via terminal or code
+    'jupyter-leaflet'                         # Prevents heavy GIS JS load, static maps can still be used in notebooks
+]
+EOF
+
+
+# --- 3. LAUNCH JUPYTER ---
+# MOVING AWAY FROM: 'jupyter lab [flags]'
+# MOVING TOWARD:   'exec jupyter lab --config' 
+# Using 'exec' ensures the container catches Slurm/OOD termination signals 
+# immediately, leading to cleaner job exits and faster resource release.
+# -----------------------------------------------------------------------------
+echo "INFO: Launching Jupyter with config file: ${CONF_FILE}"
+exec jupyter lab --config "${CONF_FILE}"

--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -82,7 +82,7 @@ c.ServerApp.jpserver_extensions = {
 
 # B. FRONTEND: Stop the Browser from requesting these icons (Fixes rendering lag)
 # By matching this list with the backend above, we prevent "Extension Missing" popups.
-c.LabApp.disabled_extensions = [
+c.LabConfig.disabled_extensions = [
     '@jupyterlab/extensionmanager-extension', # Goal to prevents CPU spike on startup
     '@jupyterlab/git',                        # Removes sidebar Git icon, git can be handled via terminal
     '@jupyterlab/github',                     # Removes sidebar GitHub icon, git can be handled via terminal

--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -18,86 +18,86 @@
 # DISABLE_FLAGS=""
 # # DISABLE_FLAGS="--LabApp.disabled_extensions='@jupyterlab/extensionmanager-extension'"
 
-# jupyter lab \
-#            --ip='0.0.0.0' \
-#            --port="${MY_JUP_PORT}" \
-#            --port-retries=0 \
-#            --ServerApp.PasswordIdentityProvider.hashed_password="${MY_JUP_PASSWD}" \
-#            --ServerApp.base_url="${MY_JUP_BASEURL}" \
-#            --no-browser \
-#            --ServerApp.allow_origin='*' \
-#            --ServerApp.disable_check_xsrf=True \
-#            --WebPDFExporter.disable_sandbox=True
+jupyter lab \
+           --ip='0.0.0.0' \
+           --port="${MY_JUP_PORT}" \
+           --port-retries=0 \
+           --ServerApp.PasswordIdentityProvider.hashed_password="${MY_JUP_PASSWD}" \
+           --ServerApp.base_url="${MY_JUP_BASEURL}" \
+           --no-browser \
+           --ServerApp.allow_origin='*' \
+           --ServerApp.disable_check_xsrf=True \
+           --WebPDFExporter.disable_sandbox=True
 
 
-# -------------------------------------------------------------------------
-# OPTIMIZED LAUNCH SCRIPT WITH SCRATCH/LUSTRE REDIRECTION
-# -------------------------------------------------------------------------
-# Optimized for Luster and High-Concurrency I/O Classes.
+# # -------------------------------------------------------------------------
+# # OPTIMIZED LAUNCH SCRIPT WITH SCRATCH/LUSTRE REDIRECTION
+# # -------------------------------------------------------------------------
+# # Optimized for Luster and High-Concurrency I/O Classes.
 
-# --- 1. SET UP PARAMETERS ---
-PORT="${MY_JUP_PORT:-8888}"
-BASE_URL="${MY_JUP_BASEURL:-/}"
-PASSWORD="${MY_JUP_PASSWD}"
-
-
-# --- 2. GENERATE RUNTIME CONFIGURATION FILE ---
-# MOVING AWAY FROM: Passing raw CLI flags (e.g., --ip, --port) which may be prone 
-#                  to shell-escaping errors and cause "Missing Extension" popups.
-#
-# MOVING TOWARD:   A generated Python config file to 
-#                  simultaneously disable Backend and Frontend components to 
-#                  fix UI sluggishness and icon "lag."
-# -----------------------------------------------------------------------------
-CONF_FILE="${PWD}/jupyter_server_config.py"
-
-cat <<EOF > "${CONF_FILE}"
-c = get_config()
-
-# --- NETWORK & SECURITY ---
-c.ServerApp.ip = '0.0.0.0'
-c.ServerApp.port = ${PORT}
-c.ServerApp.port_retries = 0
-c.ServerApp.base_url = '${BASE_URL}'
-c.ServerApp.PasswordIdentityProvider.hashed_password = '${PASSWORD}'
-c.ServerApp.allow_origin = '*'
-c.ServerApp.disable_check_xsrf = True
-c.ServerApp.open_browser = False
-c.WebPDFExporter.disable_sandbox = True
-
-# --- UI & PERFORMANCE OPTIMIZATION (THE "ICON & POPUP" FIX) ---
-# MOVING AWAY FROM: Default loading of all sidebar extensions.
-# MOVING TOWARD:   Explicitly disabling high-I/O extensions. This prevents the 
-#                  browser from "searching" for icons and status updates on 
-#                  slow storage, which fixes the "Sluggish Icon" effect.
-
-# A. BACKEND: Stop the Python server from loading these plugins (Saves RAM/CPU)
-c.ServerApp.jpserver_extensions = {
-    'dask_labextension': False,             # Constantly polls cluster status
-    'jupyter_server_xarray_leaflet': False, # Heavy GIS metadata calls
-    'jupyterlab_git': False,                # Crawls file tree for .git folders
-    'nbgitpuller': False,                   # External sync service
-    'panel.io.jupyter_server_extension': False # Dask-related, heavy JS load
-}
-
-# B. FRONTEND: Stop the Browser from requesting these icons (Fixes rendering lag)
-# By matching this list with the backend above, we prevent "Extension Missing" popups.
-c.LabConfig.disabled_extensions = [
-    '@jupyterlab/extensionmanager-extension', # Goal to prevents CPU spike on startup
-    '@jupyterlab/git',                        # Removes sidebar Git icon, git can be handled via terminal
-    '@jupyterlab/github',                     # Removes sidebar GitHub icon, git can be handled via terminal
-    '@jupyterlab/google-drive',                # Removes sidebar Drive icon, prevents heavy Google API calls
-    'dask-labextension',                      # Removes sidebar Dask icon, Dask can still be used via terminal or code
-    'jupyter-leaflet'                         # Prevents heavy GIS JS load, static maps can still be used in notebooks
-]
-EOF
+# # --- 1. SET UP PARAMETERS ---
+# PORT="${MY_JUP_PORT:-8888}"
+# BASE_URL="${MY_JUP_BASEURL:-/}"
+# PASSWORD="${MY_JUP_PASSWD}"
 
 
-# --- 3. LAUNCH JUPYTER ---
-# MOVING AWAY FROM: 'jupyter lab [flags]'
-# MOVING TOWARD:   'exec jupyter lab --config' 
-# Using 'exec' ensures the container catches Slurm/OOD termination signals 
-# immediately, leading to cleaner job exits and faster resource release.
-# -----------------------------------------------------------------------------
-echo "INFO: Launching Jupyter with config file: ${CONF_FILE}"
-exec jupyter lab --config "${CONF_FILE}"
+# # --- 2. GENERATE RUNTIME CONFIGURATION FILE ---
+# # MOVING AWAY FROM: Passing raw CLI flags (e.g., --ip, --port) which may be prone 
+# #                  to shell-escaping errors and cause "Missing Extension" popups.
+# #
+# # MOVING TOWARD:   A generated Python config file to 
+# #                  simultaneously disable Backend and Frontend components to 
+# #                  fix UI sluggishness and icon "lag."
+# # -----------------------------------------------------------------------------
+# CONF_FILE="${PWD}/jupyter_server_config.py"
+
+# cat <<EOF > "${CONF_FILE}"
+# c = get_config()
+
+# # --- NETWORK & SECURITY ---
+# c.ServerApp.ip = '0.0.0.0'
+# c.ServerApp.port = ${PORT}
+# c.ServerApp.port_retries = 0
+# c.ServerApp.base_url = '${BASE_URL}'
+# c.ServerApp.PasswordIdentityProvider.hashed_password = '${PASSWORD}'
+# c.ServerApp.allow_origin = '*'
+# c.ServerApp.disable_check_xsrf = True
+# c.ServerApp.open_browser = False
+# c.WebPDFExporter.disable_sandbox = True
+
+# # --- UI & PERFORMANCE OPTIMIZATION (THE "ICON & POPUP" FIX) ---
+# # MOVING AWAY FROM: Default loading of all sidebar extensions.
+# # MOVING TOWARD:   Explicitly disabling high-I/O extensions. This prevents the 
+# #                  browser from "searching" for icons and status updates on 
+# #                  slow storage, which fixes the "Sluggish Icon" effect.
+
+# # A. BACKEND: Stop the Python server from loading these plugins (Saves RAM/CPU)
+# c.ServerApp.jpserver_extensions = {
+#     'dask_labextension': False,             # Constantly polls cluster status
+#     'jupyter_server_xarray_leaflet': False, # Heavy GIS metadata calls
+#     'jupyterlab_git': False,                # Crawls file tree for .git folders
+#     'nbgitpuller': False,                   # External sync service
+#     'panel.io.jupyter_server_extension': False # Dask-related, heavy JS load
+# }
+
+# # B. FRONTEND: Stop the Browser from requesting these icons (Fixes rendering lag)
+# # By matching this list with the backend above, we prevent "Extension Missing" popups.
+# c.LabConfig.disabled_extensions = [
+#     '@jupyterlab/extensionmanager-extension', # Goal to prevents CPU spike on startup
+#     '@jupyterlab/git',                        # Removes sidebar Git icon, git can be handled via terminal
+#     '@jupyterlab/github',                     # Removes sidebar GitHub icon, git can be handled via terminal
+#     '@jupyterlab/google-drive',                # Removes sidebar Drive icon, prevents heavy Google API calls
+#     'dask-labextension',                      # Removes sidebar Dask icon, Dask can still be used via terminal or code
+#     'jupyter-leaflet'                         # Prevents heavy GIS JS load, static maps can still be used in notebooks
+# ]
+# EOF
+
+
+# # --- 3. LAUNCH JUPYTER ---
+# # MOVING AWAY FROM: 'jupyter lab [flags]'
+# # MOVING TOWARD:   'exec jupyter lab --config' 
+# # Using 'exec' ensures the container catches Slurm/OOD termination signals 
+# # immediately, leading to cleaner job exits and faster resource release.
+# # -----------------------------------------------------------------------------
+# echo "INFO: Launching Jupyter with config file: ${CONF_FILE}"
+# exec jupyter lab --config "${CONF_FILE}"

--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -3,7 +3,7 @@
 # Run pyppeteer install to fix issue with exporting to pdf
 # pyppeteer-install
 
-# This scriptp was refined with the help of Gemini 3 Pro and Claude 4.5 Sonnet AI Models
+# This script was refined with the help of Gemini 3 Pro and Claude 4.5 Sonnet AI Models
 
 # -------------------------------------------------------------------------
 # OPTIONAL: DISABLE HEAVY EXTENSIONS (LEGACY CLI METHOD – NOW REPLACED)

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -100,11 +100,6 @@ export APPTAINERENV_APPEND_PATH="/opt/slurm/bin"
 # enable this only if needed for debug purpose. note that the password will appear in the output 
 # set -x
 
-# # Pass connection info to container launch script
-# export APPTAINERENV_MY_JUP_PORT="${port}"
-# export APPTAINERENV_MY_JUP_PASSWD="${password}"
-# export APPTAINERENV_MY_JUP_BASEURL="${base_url}"
-
 ## bind parts of the filesystem to be able to talk to slurm from within the container
 export SING_BINDS=""
 export SING_BINDS="$SING_BINDS -B /shared"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -78,7 +78,7 @@ log "Using Persistent Workdir: ${WORKDIR_USER}"
 # -------------------------------------------------------------------------
 # We use WORKDIR_USER for Workspace/Runtime so tabs persist between sessions.
 export APPTAINERENV_JUPYTERLAB_WORKSPACES_DIR="${WORKDIR_USER}/workspaces"
-# export APPTAINERENV_JUPYTER_RUNTIME_DIR="${WORKDIR_USER}/runtime"
+export APPTAINERENV_JUPYTER_RUNTIME_DIR="${WORKDIR_USER}/runtime"
 # For pip and general cache
 export APPTAINERENV_XDG_CACHE_HOME="${WORKDIR_USER}/cache"
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -78,7 +78,7 @@ log "Using Persistent Workdir: ${WORKDIR_USER}"
 # -------------------------------------------------------------------------
 # We use WORKDIR_USER for Workspace/Runtime so tabs persist between sessions.
 export APPTAINERENV_JUPYTERLAB_WORKSPACES_DIR="${WORKDIR_USER}/workspaces"
-export APPTAINERENV_JUPYTER_RUNTIME_DIR="${WORKDIR_USER}/runtime"
+# export APPTAINERENV_JUPYTER_RUNTIME_DIR="${WORKDIR_USER}/runtime"
 # For pip and general cache
 export APPTAINERENV_XDG_CACHE_HOME="${WORKDIR_USER}/cache"
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -100,10 +100,10 @@ export APPTAINERENV_APPEND_PATH="/opt/slurm/bin"
 # enable this only if needed for debug purpose. note that the password will appear in the output 
 # set -x
 
-# Pass connection info to container launch script
-export APPTAINERENV_MY_JUP_PORT="${port}"
-export APPTAINERENV_MY_JUP_PASSWD="${password}"
-export APPTAINERENV_MY_JUP_BASEURL="${base_url}"
+# # Pass connection info to container launch script
+# export APPTAINERENV_MY_JUP_PORT="${port}"
+# export APPTAINERENV_MY_JUP_PASSWD="${password}"
+# export APPTAINERENV_MY_JUP_BASEURL="${base_url}"
 
 ## bind parts of the filesystem to be able to talk to slurm from within the container
 export SING_BINDS=""

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -35,44 +35,75 @@ fi
 #export container_folder=$HOME/Programs/containers
 export container_image=$container_folder/$IMAGE_FILE
 
-# Set additional variables
-JUPYTER_TMPDIR=${TMPDIR:-/tmp}/$(id -un)-jupyter/
-## job specific tmp in case there are conflicts with different users running on the same node
-WORKDIR=/scratch/${USER}/${SLURM_JOB_ID}
-mkdir -m 700 -p ${WORKDIR}/tmp
 
-# OPTIONAL: Set Up Scratch/Lustre Working Directory for Jupyter Cache, and Runtime"
+# # Set additional variables
+# Removed: # JUPYTER_TMPDIR=${TMPDIR:-/tmp}/$(id -un)-jupyter/
+# in favor of WORKDIR_USER and WORKDIR_JOB below
+# Replaced by scratch with working directory user
+# New implmentation:
+# 1. Redirects all caches to single high-speed, parallel I/O lustre path that persists across jobs with 1 variable.
+# 2. Moves tmp to job-specific scratch that is cleaned up after job ends to avoid conflicts.
+# 3. Users persistent workspace and runtime dirs to preserve session state across jobs, allowing browser to cache icons and UI state to load faster
+# subsequent loggings. 
+
+
+# --- STORAGE STRATEGY ---
+# WORKDIR_JOB: (Previously WORKDIR) Deleted after the job ends (good for /tmp). Used here to minimize
+# conflicts between multiple users on the same node and IOPS on shared /tmp.
+# WORKDIR_USER: Persistent across jobs (good for /scratch/$USER).
+## job specific tmp in case there are conflicts with different users running on the same node
+WORKDIR_JOB=/scratch/${USER}/${SLURM_JOB_ID}
+WORKDIR_USER="/scratch/${USER}/jupyter_persistent_state"
+
+
+# OPTIONAL: For performance improvements, set Up Scratch/Lustre Working Directory for Jupyter Cache, and Runtime"
 # -------------------------------------------------------------------------
-# mkdir -m 700 -p "${WORKDIR}"/{runtime,cache}
+# Create Scratch/Lustre Working Directories for Jupyter Cache, Runtime, and Tmp
+mkdir -m 700 -p "${WORKDIR_JOB}/tmp"
+mkdir -m 700 -p "${WORKDIR_USER}/"{runtime,cache,workspaces}
+
+log "Using Job Workdir: ${WORKDIR_JOB}"
+log "Using Persistent Workdir: ${WORKDIR_USER}"
 
 # OPTIONAL: REDIRECT JUPYTER CACHE, RUNTIME, and TMP to Scratch/Lustre
 # This prevents heavy I/O on EFS home directories.
-# Jupyter writes frequent "heartbeat" files, sockets, and logs. By default, 
-# these go to the user's Home directory (EFS). 
+# Jupyter makes high-frequency meta wirtes ("heartbeat" files, sockets, and logs). 
+# By default, these go to the user's Home directory (EFS).
 # If a large class (50+ students) launches simultaneously, thousands of tiny 
 # writes can hit the EFS IOPS limit, causing the storage to "freeze" for everyone.
 # TO ENABLE: Uncomment the block below to force these temporary files onto Lustre.
 # This isolates the I/O load and protects the Home directory.
+# These move high-frequency metadata writes to Lustre.
+# We use WORKDIR_USER for Workspace/Runtime so tabs persist between sessions.
 # -------------------------------------------------------------------------
-# export APPTAINERENV_JUPYTER_RUNTIME_DIR="${WORKDIR}/runtime"
-# export APPTAINERENV_XDG_CACHE_HOME="${WORKDIR}/cache"
-# export APPTAINERENV_TMPDIR="${WORKDIR}/tmp"
+# We use WORKDIR_USER for Workspace/Runtime so tabs persist between sessions.
+export APPTAINERENV_JUPYTERLAB_WORKSPACES_DIR="${WORKDIR_USER}/workspaces"
+export APPTAINERENV_JUPYTER_RUNTIME_DIR="${WORKDIR_USER}/runtime"
+# For pip and general cache
+export APPTAINERENV_XDG_CACHE_HOME="${WORKDIR_USER}/cache"
 
+# Use the Job-specific scratch for TMP to ensure clean cleanup after job ends
+export APPTAINERENV_TMPDIR="/tmp"
 
 
 # Create environment variables to pass to singularity container
 # See https://apptainer.org/docs/user/latest/appendix.html#e for info
 ## for conda
 export APPTAINERENV_CONDA_PKGS_DIRS=${HOME}/.conda/pkgs
-## for pip
-export APPTAINERENV_XDG_CACHE_HOME=${JUPYTER_TMPDIR}/xdg_cache_home
+## for pip (hanlded above.)
+# export APPTAINERENV_XDG_CACHE_HOME=${JUPYTER_TMPDIR}/xdg_cache_home
 ## for specific package mne
-export APPTAINERENV_NUMBA_CACHE_DIR=$HOME/.cache
+export APPTAINERENV_NUMBA_CACHE_DIR="${WORKDIR_USER}/cache/numba"
 ## Add slurm executables to PATH
 export APPTAINERENV_APPEND_PATH="/opt/slurm/bin"
 
 # enable this only if needed for debug purpose. note that the password will appear in the output 
 # set -x
+
+# Pass connection info to container launch script
+export APPTAINERENV_MY_JUP_PORT="${port}"
+export APPTAINERENV_MY_JUP_PASSWD="${password}"
+export APPTAINERENV_MY_JUP_BASEURL="${base_url}"
 
 ## bind parts of the filesystem to be able to talk to slurm from within the container
 export SING_BINDS=""

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,4 +1,4 @@
- #!/bin/bash
+#!/bin/bash
 
 this_script="template/script.sh.erb"
 
@@ -6,128 +6,208 @@ log() {
     echo -e "[$(date -Iseconds)][${this_script}] $1"
 }
 
-# Benchmark info
+# ---------------------------------------------------------------------------
+# Main entry
+# This script was refined with the help of Gemini 3 Pro and Claude 4.5 Sonnet AI Models
+# ---------------------------------------------------------------------------
+
 log "Starting main script"
 
-# Set working directory to home directory
+# Always start in the user's home directory
 cd "${HOME}"
 
-# Define Image Path 
-# Only pangeo-notebook.sif has been migrated to Lustre (/scratch). 
-# All other images should default to the EFS (/shared) location for safety.
+# ---------------------------------------------------------------------------
+# Container image selection
+#
+# - IMAGE_FILE is provided by the OOD app context (ERB: <%= context.imagefile %>).
+# - pangeo-notebook.sif is stored on Lustre (/scratch) to benefit from
+#   fast, parallel I/O.
+# - All other images default to EFS (/shared) for safety and consistency.
+# ---------------------------------------------------------------------------
 
-# The image selected passed in via the context variable 'imagefile'
 IMAGE_FILE="<%= context.imagefile %>"
 
-if [[ "$IMAGE_FILE" == "pangeo-notebook.sif" ]]; then
+if [[ "${IMAGE_FILE}" == "pangeo-notebook.sif" ]]; then
     # FAST PATH (Lustre)
     log "Image is Pangeo Notebook, using Lustre path for container image."
-    export container_folder=/scratch/apptainerImages/
+    export container_folder="/scratch/apptainerImages"
 else
     # STANDARD PATH (EFS)
     log "Image is ${IMAGE_FILE}, using standard EFS path for container image."
-    export container_folder=/shared/apptainerImages
+    export container_folder="/shared/apptainerImages"
 fi
 
+# When testing new images locally, you can instead drop them under $HOME:
+# export container_folder="${HOME}/Programs/containers"
 
-# Set up location of apptainer image
-## when you test new installs you probaby want to drop the images locally in your home folder
-#export container_folder=$HOME/Programs/containers
-export container_image=$container_folder/$IMAGE_FILE
+export container_image="${container_folder}/${IMAGE_FILE}"
 
+# ---------------------------------------------------------------------------
+# Container image validation and fallback
+#
+# Scratch (/scratch) is ephemeral storage. Files may be removed by:
+# - Automated cluster purge policies (e.g., age-based cleanup).
+# - Manual maintenance operations.
+# - Storage capacity management.
+#
+# To ensure job reliability, we validate that the image exists at the
+# expected path. If pangeo-notebook.sif is missing from scratch, we
+# automatically fall back to the EFS copy.
+#
+# This allows jobs to continue working even if scratch is cleaned between
+# image sync cycles, at the cost of slower I/O during container startup.
+# ---------------------------------------------------------------------------
 
-# # Set additional variables
-# Removed: # JUPYTER_TMPDIR=${TMPDIR:-/tmp}/$(id -un)-jupyter/
-# in favor of WORKDIR_USER and WORKDIR_JOB below
-# Replaced by scratch with working directory user
-# New implmentation:
-# 1. Redirects all caches to single high-speed, parallel I/O lustre path that persists across jobs with 1 variable.
-# 2. Moves tmp to job-specific scratch that is cleaned up after job ends to avoid conflicts.
-# 3. Users persistent workspace and runtime dirs to preserve session state across jobs, allowing browser to cache icons and UI state to load faster
-# subsequent loggings. 
+if [[ ! -f "${container_image}" ]]; then
+    log "WARNING: Image not found at ${container_image}"
+    
+    # If we were trying scratch, fall back to EFS
+    if [[ "${container_folder}" == "/scratch/apptainerImages" ]]; then
+        log "Attempting fallback to EFS for ${IMAGE_FILE}"
+        export container_folder="/shared/apptainerImages"
+        export container_image="${container_folder}/${IMAGE_FILE}"
+        
+        if [[ -f "${container_image}" ]]; then
+            log "SUCCESS: Found image at fallback location ${container_image}"
+        else
+            log "ERROR: Image ${IMAGE_FILE} not found on scratch or EFS."
+            log "ERROR: Expected locations:"
+            log "ERROR:   - /scratch/apptainerImages/${IMAGE_FILE}"
+            log "ERROR:   - /shared/apptainerImages/${IMAGE_FILE}"
+            exit 1
+        fi
+    else
+        # We were already using EFS and it's still not there
+        log "ERROR: Image ${IMAGE_FILE} not found at ${container_image}"
+        log "ERROR: Verify the image exists and is readable."
+        exit 1
+    fi
+fi
 
+log "Using container image: ${container_image}"
 
-# --- STORAGE STRATEGY ---
-# WORKDIR_JOB: (Previously WORKDIR) Deleted after the job ends (good for /tmp). Used here to minimize
-# conflicts between multiple users on the same node and IOPS on shared /tmp.
-# WORKDIR_USER: Persistent across jobs (good for /scratch/$USER).
-## job specific tmp in case there are conflicts with different users running on the same node
-WORKDIR_JOB=/scratch/${USER}/${SLURM_JOB_ID}
+# ---------------------------------------------------------------------------
+# Scratch layout for JupyterLab runtime, caches, and /tmp
+#
+# Goals:
+# - Move high-frequency small writes (runtime, caches, icons, workspaces)
+#   off of EFS ($HOME) and onto Lustre (/scratch) to avoid EFS IOPS saturation
+#   during large, concurrent launches (e.g., entire classes).
+# - Use a per-job /tmp to avoid conflicts between jobs/users on the same node.
+# - Use a per-user persistent area for JupyterLab state so that UI assets
+#   and workspaces persist across jobs and can be quickly reused.
+#
+# Notes on Apptainer:
+# - Env vars prefixed with APPTAINERENV_ are passed into the container with
+#   the prefix stripped. For example:
+#     APPTAINERENV_JUPYTER_RUNTIME_DIR  -> JUPYTER_RUNTIME_DIR (inside)
+# ---------------------------------------------------------------------------
+
+# Per-job scratch directory: tied to a single Slurm job, safe to discard
+# when the job ends. Used for /tmp inside the container.
+WORKDIR_JOB="/scratch/${USER}/${SLURM_JOB_ID}"
+
+# Per-user persistent scratch directory for Jupyter state that should
+# survive across jobs (runtime, caches, workspaces).
 WORKDIR_USER="/scratch/${USER}/jupyter_persistent_state"
 
-
-# OPTIONAL: For performance improvements, set Up Scratch/Lustre Working Directory for Jupyter Cache, and Runtime"
-# -------------------------------------------------------------------------
-# Create Scratch/Lustre Working Directories for Jupyter Cache, Runtime, and Tmp
+# Create job-specific /tmp and persistent Jupyter state dirs
 mkdir -m 700 -p "${WORKDIR_JOB}/tmp"
-mkdir -m 700 -p "${WORKDIR_USER}/"{runtime,cache,workspaces}
+mkdir -m 700 -p "${WORKDIR_USER}"/{runtime,cache,workspaces}
 
-log "Using Job Workdir: ${WORKDIR_JOB}"
-log "Using Persistent Workdir: ${WORKDIR_USER}"
+log "Using job workdir: ${WORKDIR_JOB}"
+log "Using persistent workdir: ${WORKDIR_USER}"
 
-# OPTIONAL: REDIRECT JUPYTER CACHE, RUNTIME, and TMP to Scratch/Lustre
-# This prevents heavy I/O on EFS home directories.
-# Jupyter makes high-frequency meta wirtes ("heartbeat" files, sockets, and logs). 
-# By default, these go to the user's Home directory (EFS).
-# If a large class (50+ students) launches simultaneously, thousands of tiny 
-# writes can hit the EFS IOPS limit, causing the storage to "freeze" for everyone.
-# TO ENABLE: Uncomment the block below to force these temporary files onto Lustre.
-# This isolates the I/O load and protects the Home directory.
-# These move high-frequency metadata writes to Lustre.
-# We use WORKDIR_USER for Workspace/Runtime so tabs persist between sessions.
-# -------------------------------------------------------------------------
-# We use WORKDIR_USER for Workspace/Runtime so tabs persist between sessions.
+# JupyterLab workspaces: tab/layout metadata. Keeping this persistent lets
+# users reconnect to familiar layouts quickly.
 export APPTAINERENV_JUPYTERLAB_WORKSPACES_DIR="${WORKDIR_USER}/workspaces"
+
+# Jupyter runtime files: heartbeats, sockets, and logs. These are very
+# chatty; moving them to Lustre avoids hammering EFS.
 export APPTAINERENV_JUPYTER_RUNTIME_DIR="${WORKDIR_USER}/runtime"
-# For pip and general cache
+
+# General caches (e.g., pip, Jupyter caches) use XDG_CACHE_HOME.
 export APPTAINERENV_XDG_CACHE_HOME="${WORKDIR_USER}/cache"
 
-# Use the Job-specific scratch for TMP to ensure clean cleanup after job ends
-export APPTAINERENV_TMPDIR="/tmp"
-
-
-# Create environment variables to pass to singularity container
-# See https://apptainer.org/docs/user/latest/appendix.html#e for info
-## for conda
-export APPTAINERENV_CONDA_PKGS_DIRS=${HOME}/.conda/pkgs
-## for pip (hanlded above.)
-# export APPTAINERENV_XDG_CACHE_HOME=${JUPYTER_TMPDIR}/xdg_cache_home
-## for specific package mne
+# numba cache: compiled kernels – can be large and frequently updated.
 export APPTAINERENV_NUMBA_CACHE_DIR="${WORKDIR_USER}/cache/numba"
-## Add slurm executables to PATH
+
+# Inside the container, TMPDIR will point at the job-specific scratch /tmp.
+# This isolates temporary files per job and ties cleanup to job lifetime.
+export APPTAINERENV_TMPDIR="${WORKDIR_JOB}/tmp"
+
+# If we ever need to revert to a home-based tmp/cache model, the
+# legacy pattern (kept here for reference) was:
+#   JUPYTER_TMPDIR=${TMPDIR:-/tmp}/$(id -un)-jupyter/
+#   APPTAINERENV_XDG_CACHE_HOME="${JUPYTER_TMPDIR}/xdg_cache_home"
+
+# ---------------------------------------------------------------------------
+# Additional environment passed into the Apptainer container
+# ---------------------------------------------------------------------------
+
+# Conda package cache stays in $HOME; less write-churn than Jupyter runtime.
+export APPTAINERENV_CONDA_PKGS_DIRS="${HOME}/.conda/pkgs"
+
+# Add Slurm executables to PATH inside the container.
 export APPTAINERENV_APPEND_PATH="/opt/slurm/bin"
 
-# enable this only if needed for debug purpose. note that the password will appear in the output 
+# Enable this only if needed for debug purposes.
+# Note: the password may appear in output if used interactively.
 # set -x
 
-## bind parts of the filesystem to be able to talk to slurm from within the container
+# ---------------------------------------------------------------------------
+# Filesystem bindings for Apptainer
+#
+# SING_BINDS is expanded into a sequence of `-B` flags for apptainer exec.
+# We bind:
+# - /shared  : EFS (homes, shared data, non-Pangeo images)
+# - /scratch : Lustre scratch (images, Jupyter state, tmp)
+# - WORKDIR_JOB/tmp -> /tmp inside the container (per-job tmp)
+#
+# Additional Slurm/SSSD bindings are kept commented together below for easy
+# re-enable if needed for debugging or enhanced integration.
+# ---------------------------------------------------------------------------
+
 export SING_BINDS=""
-export SING_BINDS="$SING_BINDS -B /shared"
-export SING_BINDS="$SING_BINDS -B /scratch"
-# export SING_BINDS="$SING_BINDS -B /etc/nsswitch.conf"
-# export SING_BINDS="$SING_BINDS -B /etc/sssd/"
-# export SING_BINDS="$SING_BINDS -B /var/lib/sss"
-# export SING_BINDS="$SING_BINDS -B /opt/slurm"
-# export SING_BINDS="$SING_BINDS -B /slurm" # location does not exist, unsure of purpose
-# export SING_BINDS="$SING_BINDS -B /var/run/munge"
-# export SING_BINDS="$SING_BINDS -B `which sbatch `"
-# export SING_BINDS="$SING_BINDS -B `which srun `"
-# export SING_BINDS="$SING_BINDS -B `which sacct `"
-# export SING_BINDS="$SING_BINDS -B `which scontrol `"
-# export SING_BINDS="$SING_BINDS -B `which salloc `"
-# export SING_BINDS="$SING_BINDS -B /usr/lib64/slurm/ " # location does not exist, unsure of purpose
-# export SING_BINDS="$SING_BINDS -B /usr/lib64/libreadline.so.6" # missing file, causing issues with scontrol
-export SING_BINDS="$SING_BINDS -B ${WORKDIR}/tmp:/tmp " ## job specific tmp dir
+export SING_BINDS="${SING_BINDS} -B /shared"
+export SING_BINDS="${SING_BINDS} -B /scratch"
+
+# Optional system/Slurm bindings (kept for reference):
+# export SING_BINDS="${SING_BINDS} -B /etc/nsswitch.conf"
+# export SING_BINDS="${SING_BINDS} -B /etc/sssd/"
+# export SING_BINDS="${SING_BINDS} -B /var/lib/sss"
+# export SING_BINDS="${SING_BINDS} -B /opt/slurm"
+# export SING_BINDS="${SING_BINDS} -B /slurm"                # path does not exist
+# export SING_BINDS="${SING_BINDS} -B /var/run/munge"
+# export SING_BINDS="${SING_BINDS} -B $(which sbatch)"
+# export SING_BINDS="${SING_BINDS} -B $(which srun)"
+# export SING_BINDS="${SING_BINDS} -B $(which sacct)"
+# export SING_BINDS="${SING_BINDS} -B $(which scontrol)"
+# export SING_BINDS="${SING_BINDS} -B $(which salloc)"
+# export SING_BINDS="${SING_BINDS} -B /usr/lib64/slurm/"     # path may not exist
+# export SING_BINDS="${SING_BINDS} -B /usr/lib64/libreadline.so.6" # missing on some nodes
+
+# Bind the job-specific scratch tmp as /tmp inside the container.
+export SING_BINDS="${SING_BINDS} -B ${WORKDIR_JOB}/tmp:/tmp"
+
 log "SING_BINDS=${SING_BINDS}"
 
+# JOBROOT is set by the OOD app; it points at the app's job directory
+# containing jupyter.script.sh and related helper scripts.
 log "JOBROOT=${JOBROOT}"
+
+# ---------------------------------------------------------------------------
+# Load Apptainer via Spack and launch Jupyter
+# ---------------------------------------------------------------------------
 
 log "Starting to load Spack environment"
 
-# Load apptainer from spack before running image
+# Load apptainer from Spack before running the container image
 . /shared/spack/share/spack/setup-env.sh
 spack env activate apptainer
 
 log "Starting Jupyter"
 
-apptainer exec $SING_BINDS $container_image $JOBROOT/jupyter.script.sh
+# apptainer exec will see the environment above (APPTAINERENV_*) and
+# the bind mounts specified in SING_BINDS.
+apptainer exec ${SING_BINDS} "${container_image}" "${JOBROOT}/jupyter.script.sh"


### PR DESCRIPTION
# Optimize JupyterLab launch w/ scratch and disabling heavy extensions, after image moved to scratch.

## Overview

Fixes **INC06182616** (EPS 101, 2026-01-28): students experienced ~26-minute blank screens during Jupyter launches despite backend "Ready" status within minutes.

This is PR is well commented to clearly share logic, reasoning, tool information, and rollback.

**Root causes:** Large image and High-frequency JupyterLab metadata writes (runtime, caches, UI assets) hitting EFS during concurrent class launches saturated IOPS and delayed UI rendering.

**Solution:**
- Redirect Jupyter runtime/caches/workspaces to Lustre `/scratch` via Apptainer env vars.
- Disable high-I/O JupyterLab extensions (git, dask, extension manager, etc.).
- Switch from CLI flags to config files for better control and maintainability.
- Add scratch → EFS fallback for `pangeo-notebook.sif` to handle ephemeral storage.

<details>
<summary><strong>Incident details</strong></summary>

- **Course:** EPS 101 ([Canvas](https://canvas.harvard.edu/courses/159536))
- **Incident:** INC06182616
- **Date:** 2026-01-28
- **Symptom:** ~26 minutes of blank browser screens for entire class launching Jupyter via Open OnDemand
- **Backend status:** Healthy; container initialized and server "Ready" within minutes
- **Discrepancy:** Compute nodes were running/listening but web UI did not update for students
- **Post-mitigation testing:** Moving `pangeo-notebook.sif` to scratch reduced container startup but page loads still 4–5 minutes with "page unresponsive" popups. Cold load take longer to load.

</details>

## Changes

### `template/script.sh.erb`

**Scratch-based Jupyter state layout:**
- Introduce `WORKDIR_JOB` (per-job, ephemeral) and `WORKDIR_USER` (per-user, persistent) on `/scratch`.
- Redirect Jupyter runtime, caches, workspaces, and `/tmp` to Lustre via `APPTAINERENV_*`:
  - `JUPYTER_RUNTIME_DIR` → `${WORKDIR_USER}/runtime`
  - `JUPYTERLAB_WORKSPACES_DIR` → `${WORKDIR_USER}/workspaces`
  - `XDG_CACHE_HOME` → `${WORKDIR_USER}/cache`
  - `NUMBA_CACHE_DIR` → `${WORKDIR_USER}/cache/numba`
  - `TMPDIR` → `${WORKDIR_JOB}/tmp` (bound to `/tmp` inside container)

**Scratch → EFS fallback:**
- Validate `pangeo-notebook.sif` exists on scratch before launch.
- Automatically fall back to `/shared/apptainerImages` if missing.
- Log warnings and success/failure for operational visibility.

<details>
<summary><strong>Why scratch for Jupyter state?</strong></summary>

JupyterLab writes thousands of small files during startup and runtime:
- **Runtime:** heartbeat files, sockets, logs (high-frequency metadata updates)
- **Caches:** pip, conda, icon bundles, numba compiled kernels
- **Workspaces:** tab/layout state for UI persistence

When a large class launches simultaneously, these writes hit EFS `$HOME` and can saturate IOPS, causing the entire storage layer to "freeze."

Lustre `/scratch` is optimized for parallel I/O and high metadata throughput, making it a better fit for this workload. Persistent state (runtime, workspaces, caches) is kept in a per-user scratch directory so the browser can reuse cached assets across sessions.

</details>

<details>
<summary><strong>Why fallback to EFS?</strong></summary>

`/scratch` is ephemeral and subject to:
- Age-based purge policies
- Capacity management cleanups
- Maintenance operations

The fallback ensures jobs don't fail if `pangeo-notebook.sif` is removed from scratch between image sync cycles. Jobs automatically use the EFS copy (slower but reliable) and log the fallback for operator awareness.

</details>

---

### `jupyter.script.sh`

**Config-file-based launch:**
- Replace CLI flags with generated `page_config.json` (frontend) and `jupyter_server_config.py` (backend).
- Use `exec jupyter lab --config` for clean signal handling (Slurm TERM/INT).

**Disabled extensions:**

| Extension | Reason |
|-----------|--------|
| `@jupyterlab/extensionmanager-extension` | Fetches updates from internet on every startup (100% CPU for 2–4s) |
| `@jupyterlab/git` | Crawls filesystem for `.git` folders (heavy metadata I/O) |
| `@jupyterlab/github`, `@jupyterlab/google-drive` | External service integrations (network latency, auth popups) |
| `dask-labextension` | Constantly polls cluster status |
| `jupyter-leaflet` | Heavy GIS metadata calls |
| `jupyterlab-code-formatter` | Large JS bundle loads |
| `nbdime-jupyterlab` | Diff computation on every notebook open |
| `nbgitpuller` | External sync service |
| `panel.io.jupyter_server_extension` | Heavy JS bundle, Dask-related polling |

<details>
<summary><strong>Why disable these extensions?</strong></summary>

Each extension causes:
- **Small file loads:** icons, CSS, JS bundles (dozens of requests per extension)
- **Polling/status checks:** git status, dask cluster health, external API calls
- **Metadata scans:** searching for `.git`, checking file timestamps, diffing notebooks

When combined with EFS-backed storage and 50+ concurrent launches, these operations compound and cause the "sluggish icon" effect and "page unresponsive" browser warnings.

Disabling reduces:
- Backend CPU/I/O overhead during startup
- Frontend asset load count and rendering time
- Network latency from external service calls

Extensions can be re-enabled individually by editing `page_config.json` or `jupyter_server_config.py`.

</details>

## Notes

**Scratch storage characteristics:**
- `/scratch` is **not backed up** and subject to automated purge policies.
- Files in `WORKDIR_USER` (`/scratch/$USER/jupyter_persistent_state`) may be removed by cluster policy.
- JupyterLab will recreate runtime/caches/workspaces as needed if purged (with a slower first load).
- User work (notebooks, data) should remain in `$HOME` on EFS.

**Testing:**
- Validated fallback by renaming `pangeo-notebook.sif` on scratch; job successfully used EFS copy.
- Confirmed `APPTAINERENV_*` variables set correctly inside container via `env | grep JUPYTER`.
- Verified Jupyter runtime/caches written to `/scratch/$USER/...` (not `$HOME`) via job logs and `lsof`.
- Page loads complete without "unresponsive" popups under simulated multi-user launch patterns.

**Rollback plan:**
- To revert to EFS-backed Jupyter state: comment out the `WORKDIR_JOB`/`WORKDIR_USER` block and related `APPTAINERENV_*` exports in `template/script.sh.erb`.
- To re-enable extensions: edit `page_config.json` (frontend) or `c.ServerApp.jpserver_extensions` (backend) in `jupyter.script.sh`.

<details>
<summary><strong>Performance expectations</strong></summary>

**Before this PR:**
- Container "Ready" within 2–3 minutes
- UI blank/unresponsive for 20–30 minutes (large class launches)
- Frequent "page slow to respond" browser warnings
- EFS IOPS saturation visible in CloudWatch metrics

**After this PR (expected):**
- Container "Ready" within 2–3 minutes (unchanged)
- UI usable within 30–60 seconds of "Ready" status
- Subsequent launches faster (cached workspaces/assets reused)
- Reduced EFS IOPS load (Jupyter metadata on Lustre)

</details>

---

## References

<details>
<summary><strong>Scratch is high-performance but ephemeral / purgeable</strong></summary>

- FASRC scratch policy (temporary, high-performance, purged, not backed up):  
  https://docs.rc.fas.harvard.edu/kb/policy-scratch/

</details>

<details>
<summary><strong>Why Lustre (/scratch) is faster for concurrent I/O than NFS-style home storage</strong></summary>

- Lustre overview (distributed parallel filesystem designed for high-performance/scalability):  
  https://wiki.lustre.org/Introduction_to_Lustre

- AWS FSx for Lustre (Lustre characteristics: sub-ms latency, high throughput, millions of IOPS):  
  https://docs.aws.amazon.com/fsx/latest/LustreGuide/what-is.html  
  https://aws.amazon.com/documentation-overview/lustre/

</details>

<details>
<summary><strong>Why EFS/$HOME can struggle with many small files + metadata ops</strong></summary>

- Amazon EFS performance tips (per-operation latency overhead; small-file guidance):  
  https://docs.aws.amazon.com/efs/latest/ug/performance-tips.html

- AWS guidance on metadata-intensive operations and “many small files serially” degrading performance:  
  https://repost.aws/knowledge-center/efs-troubleshoot-slow-performance

</details>

<details>
<summary><strong>Apptainer env passthrough used to redirect Jupyter state</strong></summary>

- APPTAINERENV_* behavior (host → container env injection):  
  https://apptainer.org/docs/user/1.0/environment_and_metadata.html

</details>

<details>
<summary><strong>Jupyter runtime + cache directories referenced in this PR</strong></summary>

- Jupyter runtime dir honors JUPYTER_RUNTIME_DIR (jupyter_core):  
  https://jupyter-core.readthedocs.io/en/latest/api/jupyter_core.html

- XDG base directory spec (XDG_CACHE_HOME):  
  https://specifications.freedesktop.org/basedir-spec/0.8/

- Numba cache dir override (NUMBA_CACHE_DIR / NUMBA_CACHE_DIR semantics):  
  https://numba.pydata.org/numba-doc/0.50.1/reference/envvars.html

</details>

<details>
<summary><strong>JupyterLab extension disabling + “Extension Manager hits the internet” rationale</strong></summary>

- JupyterLab: disabling extensions via labconfig/page_config.json (disabledExtensions precedence):  
  https://jupyterlab.readthedocs.io/en/stable/user/extensions.html  
  https://jupyterlab.readthedocs.io/en/3.6.x/user/directories.html

- JupyterLab Extension Manager uses PyPI.org + pip (network access + requests/caching knobs):  
  https://jupyterlab.readthedocs.io/en/4.3.x/user/extensions.html

</details>

<details>
<summary><strong>Docs supporting “some extensions poll the filesystem / external services”</strong></summary>

- jupyterlab-git: polls filesystem for changes (refreshInterval) + notes about performance degradation:  
  https://github.com/jupyterlab/jupyterlab-git

- nbgitpuller: sync/pull a git repo into a live Jupyter session (external repo I/O):  
  https://github.com/jupyterhub/nbgitpuller  
  https://nbgitpuller.readthedocs.io/en/latest/use.html

- Dask JupyterLab extension (cluster management + dashboard embedding implies ongoing status/UI updates):  
  https://pypi.org/project/dask-labextension/

- Panel Jupyter server extension (adds handlers + websocket/server session plumbing):  
  https://panel.holoviz.org/api/panel.io.jupyter_server_extension.html

</details>