### PR TITLE
add tinytex package

### DIFF
--- a/build/jupyter-econ1123-v20260205.a.def
+++ b/build/jupyter-econ1123-v20260205.a.def
@@ -1,0 +1,97 @@
+Bootstrap:localimage
+From: /shared/apptainerImages/datascience-notebook.sif
+# For this build, I pulled from a local image file that had already been created to speed up the build process. I'm not sure if this is something we want to make a more general pattern, though.
+
+%post -c /bin/bash
+echo "shell: $0"
+
+apt-get update && apt-get -y install \
+    cmake \
+    libfreetype6-dev \
+    libfontconfig1-dev \
+    libharfbuzz-dev \
+    libfribidi-dev
+
+cat << EOF > /tmp/requirements.txt
+arch
+# fixedeffect # Unclear that this is a python package
+fredapi
+linearmodels
+matplotlib
+numpy
+pandas
+rddensity
+scipy
+scikit-learn
+stargazer
+statsmodels
+rdrobust
+binsreg
+seaborn
+lpdensity
+EOF
+
+pip install -r /tmp/requirements.txt
+
+R_PACKAGES=(
+    "AER" 
+    "MASS"
+    "binsreg"
+    "boot"
+    "broom"
+    "car"
+    "data.table"
+    "dfadjust"
+    "dplyr"
+    "estimatr"
+    "fixest"
+    "gamlr"
+    "ggplot2"
+    "haven"
+    "ivDiag"
+    "jsonlite"
+    "kableExtra"
+    "lfe"
+    "lib"
+    "lmtest"
+    "lpdensity"
+    "lubridate"
+    "maptpx"
+    "margins"
+    "msm"
+    "np"
+    "nprobust"
+    "oglmx"
+    "randomForest"
+    "remotes"
+    "rdrobust"
+    "rpart"
+    "rpart.plot"
+    "rugarch"
+    "ranger"
+    "sampleSelection"
+    "sandwich"
+    "stargazer"
+    "statar"
+    "textir"
+    "tidyverse"
+    "tinytex"
+    "tm"
+    "zoo"
+)
+
+R_GH_PACKAGES=(
+    "OpportunityInsights/oiplot"
+    "grantmcdermott/lfe2fixest"
+    "manutzn/fredo"
+)
+
+for package in "${R_PACKAGES[@]}"
+do
+Rscript -e "install.packages(\"${package}\", repos=\"https://archive.linux.duke.edu/cran/\")"
+done
+
+for package in "${R_GH_PACKAGES[@]}"
+do
+Rscript -e "devtools::install_github(\"${package}\")"
+done

--- a/local/econ1123.yml.erb
+++ b/local/econ1123.yml.erb
@@ -74,7 +74,7 @@ attributes:
   # when starting the app via apptainer. The .sif file must exist at 
   # /shared/apptainerImages. The build definition for any app referenced by a
   # sub-app should be included in the build folder as a .def file.
-  imagefile: "jupyter-econ1123.sif"
+  imagefile: "jupyter-econ1123-v20260205.a.sif"
 
   # How many CPU cores to include in the slurm job submission
   custom_num_cores:

--- a/local/econ50.yml.erb
+++ b/local/econ50.yml.erb
@@ -74,7 +74,7 @@ attributes:
   # when starting the app via apptainer. The .sif file must exist at 
   # /shared/apptainerImages. The build definition for any app referenced by a
   # sub-app should be included in the build folder as a .def file.
-  imagefile: "jupyter-econ1123.sif"
+  imagefile: "jupyter-econ1123-v20260205.a.sif"
 
   # How many CPU cores to include in the slurm job submission
   custom_num_cores:


### PR DESCRIPTION
## Overview
For econ1123 and econ50, faculty asked for additional package `tinytex`, rebuilding image with the additional package, will shift the course over from original image `jupyter-econ1123.sif` to the update version, `jupyter-econ1123-v020260205.a.sif`

## Changes
- diff -u build/jupyter-econ1123.def build/jupyter-econ1123-v20260205.a.def

```diff
--- build/jupyter-econ1123.def  2026-02-04 02:54:13
+++ build/jupyter-econ1123-v20260205.a.def      2026-02-05 11:45:00
@@ -75,6 +75,7 @@
     "statar"
     "textir"
     "tidyverse"
+    "tinytex"
     "tm"
     "zoo"
 )
```

- updated `local/econ50.yml.erb` and `local/econ1123.yml.erb` to from `jupyter-econ1123.sif` to `jupyter-econ1123-v20260205.a.sif`

## Notes
Details on request 
- SNOW Ticket: [INC06159404](https://harvard.service-now.com/now/nav/ui/classic/params/target/incident.do%3Fsys_id%3D99e6e0392b5e7e1848cafa95e391bf53)
- Suggested Strategy In [Story ATGU-5524](https://at-harvard.atlassian.net/browse/ATGU-5524): 

### Testing
- In apptainer, I copied the `econ2133.yml.erb` to `adminecon.yml.erb`,  created a Jupyter Lab - ECON ADMIN course on prod.
<details><summary>[root@ip-10-37-33-16 local]# diff -u econ1123.yml.erb adminecon.yml.erb</summary>

```diff
[root@ip-10-37-33-16 local]# diff -u econ1123.yml.erb adminecon.yml.erb
--- econ1123.yml.erb    2026-01-27 11:13:53.376038635 -0500
+++ adminecon.yml.erb   2026-02-05 14:28:29.836536835 -0500
@@ -14,7 +14,7 @@
 # Specify course groups by Canvas course ID, which you can find in a url:
 # canvas.harvard.edu/courses/000000
 enabledGroups = [
-  "159573" # Econ 1123
+#  "159573" # Econ 1123
 ]

 def arrays_have_common_element(array1, array2)
@@ -43,7 +43,7 @@
 -%>
 ---
 cluster: "<%= cluster %>"
-title: "Jupyter Lab - ECON 1123"
+title: "Jupyter Lab - ECON ADMIN"

 # Form attributes that will be presented to the user and available to the
 # scripts that launch the app. Think of this as initializing variables for use
@@ -74,7 +74,7 @@
   # when starting the app via apptainer. The .sif file must exist at
   # /shared/apptainerImages. The build definition for any app referenced by a
   # sub-app should be included in the build folder as a .def file.
-  imagefile: "jupyter-econ1123.sif"
+  imagefile: "jupyter-econ1123-v20260205.a.sif"

   # How many CPU cores to include in the slurm job submission
   custom_num_cores:

```

</details>

<details><summary>Loaded ECON ADMIN apptainer pointing to updated image</summary>

```diff
[2026-02-05T19:29:12+00:00][template/before.sh.erb] original HOME=/home/prg038
[2026-02-05T19:29:12+00:00][template/before.sh.erb] user=prg038
[2026-02-05T19:29:12+00:00][template/before.sh.erb] new HOME=/shared/home/prg038
Script starting...
[2026-02-05T19:29:12+00:00][template/after.sh] Waiting for Jupyter Notebook server to open port 9299...
[2026-02-05T19:29:12+00:00][template/script.sh.erb] Starting main script
[2026-02-05T19:29:12+00:00][template/after.sh] Starting wait
[2026-02-05T19:29:12+00:00][template/script.sh.erb] Image is jupyter-econ1123-v20260205.a.sif, using standard EFS path for container image.
[2026-02-05T19:29:12+00:00][template/script.sh.erb] Using container image: /shared/apptainerImages/jupyter-econ1123-v20260205.a.sif
[2026-02-05T19:29:12+00:00][template/script.sh.erb] Using job workdir: /scratch/prg038/72170
[2026-02-05T19:29:12+00:00][template/script.sh.erb] Using persistent workdir: /scratch/prg038/jupyter_persistent_state
[2026-02-05T19:29:12+00:00][template/script.sh.erb] SING_BINDS= -B /shared -B /scratch -B /scratch/prg038/72170/tmp:/tmp
[2026-02-05T19:29:12+00:00][template/script.sh.erb] JOBROOT=/shared/home/prg038/ondemand/data/sys/dashboard/batch_connect/sys/ood-jupyterlab-apptainer/adminecon/output/1f7b2896-872f-4e9c-895b-e75e98d9a3d2
[2026-02-05T19:29:12+00:00][template/script.sh.erb] Starting to load Spack environment
[2026-02-05T19:29:34+00:00][template/script.sh.erb] Starting Jupyter
INFO: Launching JupyterLab with config file: /shared/home/prg038/jupyter_server_config.py
```
</details>

Confirmed tinytext package was available, loaded, and created pdf from tex file.
<img width="815" height="600" alt="Screenshot 2026-02-05 at 3 03 15 PM" src="https://github.com/user-attachments/assets/c5d1ac28-4ce6-4eb8-9b3e-51d5e5ede3f6" />



## References
- Faculty suggested repo: `https://cloud.r-project.org` and our standard repo for R packages `https://archive.linux.duke.edu/cran/` pull from the same source, CRAN. [`tinytex` package](https://archive.linux.duke.edu/cran//web/packages/tinytex/index.html) found in the repository.