### PR TITLE
Scratch / Jupyter Clean Up - Clean Home directories, Move configs to ephemeral storage bound to container

### DIFF
--- a/template/jupyter.script.sh
+++ b/template/jupyter.script.sh
@@ -15,25 +15,28 @@
 # DISABLE_FLAGS=""
 # DISABLE_FLAGS="--LabApp.disabled_extensions='@jupyterlab/extensionmanager-extension'"
 
-# jupyter lab \
-#            --ip='0.0.0.0' \
-#            --port="${MY_JUP_PORT}" \
-#            --port-retries=0 \
-#            --ServerApp.PasswordIdentityProvider.hashed_password="${MY_JUP_PASSWD}" \
-#            --ServerApp.base_url="${MY_JUP_BASEURL}" \
-#            --no-browser \
-#            --ServerApp.allow_origin='*' \
-#            --ServerApp.disable_check_xsrf=True \
-#            --WebPDFExporter.disable_sandbox=True
+echo "INFO: Launching Jupyter. System configs provided via Apptainer bind mounts."
+
+# Using 'exec' ensures clean shutdown signals from Slurm are caught by Jupyter
+exec jupyter lab \
+           --ip='0.0.0.0' \
+           --port="${MY_JUP_PORT}" \
+           --port-retries=0 \
+           --ServerApp.PasswordIdentityProvider.hashed_password="${MY_JUP_PASSWD}" \
+           --ServerApp.base_url="${MY_JUP_BASEURL}" \
+           --no-browser \
+           --ServerApp.allow_origin='*' \
+           --ServerApp.disable_check_xsrf=True \
+           --WebPDFExporter.disable_sandbox=True
 
 # -------------------------------------------------------------------------
 # OPTIMIZED LAUNCH SCRIPT USING GENERATED CONFIG
 # -------------------------------------------------------------------------
 
 # Basic server parameters from the OOD/apptainer environment
-PORT="${MY_JUP_PORT:-8888}"
-BASE_URL="${MY_JUP_BASEURL:-/}"
-PASSWORD="${MY_JUP_PASSWD}"
+# PORT="${MY_JUP_PORT:-8888}"
+# BASE_URL="${MY_JUP_BASEURL:-/}"
+# PASSWORD="${MY_JUP_PASSWD}"
 
 # -------------------------------------------------------------------------
 # 1. FRONTEND: disable heavy JupyterLab extensions via page_config.json
@@ -42,57 +45,58 @@ PASSWORD="${MY_JUP_PASSWD}"
 # Disabling high-I/O / external service integrations here reduces the
 # number of small asset loads and API calls during startup.
 # -------------------------------------------------------------------------
-LABCONFIG_DIR="${HOME}/.jupyter/labconfig"
-mkdir -p "${LABCONFIG_DIR}"
 
-cat > "${LABCONFIG_DIR}/page_config.json" <<'EOF'
-{
-  "disabledExtensions": {
-    "@jupyterlab/extensionmanager-extension": true,
-    "@jupyterlab/git": true,
-    "@jupyterlab/github": true,
-    "@jupyterlab/google-drive": true,
-    "dask-labextension": true,
-    "jupyter-leaflet": true,
-    "jupyterlab-code-formatter": true,
-    "nbdime-jupyterlab": true
-  }
-}
-EOF
+# LABCONFIG_DIR="${HOME}/.jupyter/labconfig"
+# mkdir -p "${LABCONFIG_DIR}"
 
-# -------------------------------------------------------------------------
-# 2. BACKEND: generate a temporary jupyter_server_config.py
-#
-# This replaces long CLI flag lists with a single config file that:
-# - Sets the usual ServerApp network/security options.
-# - Disables selected jpserver extensions that do heavy polling or I/O.
-# -------------------------------------------------------------------------
-CONF_FILE="${PWD}/jupyter_server_config.py"
+# cat > "${LABCONFIG_DIR}/page_config.json" <<'EOF'
+# {
+#   "disabledExtensions": {
+#     "@jupyterlab/extensionmanager-extension": true,
+#     "@jupyterlab/git": true,
+#     "@jupyterlab/github": true,
+#     "@jupyterlab/google-drive": true,
+#     "dask-labextension": true,
+#     "jupyter-leaflet": true,
+#     "jupyterlab-code-formatter": true,
+#     "nbdime-jupyterlab": true
+#   }
+# }
+# EOF
 
-cat <<EOF > "${CONF_FILE}"
-c = get_config()
+# # -------------------------------------------------------------------------
+# # 2. BACKEND: generate a temporary jupyter_server_config.py
+# #
+# # This replaces long CLI flag lists with a single config file that:
+# # - Sets the usual ServerApp network/security options.
+# # - Disables selected jpserver extensions that do heavy polling or I/O.
+# # -------------------------------------------------------------------------
+# CONF_FILE="${PWD}/jupyter_server_config.py"
 
-# --- NETWORK & SECURITY ---
-c.ServerApp.ip = '0.0.0.0'
-c.ServerApp.port = ${PORT}
-c.ServerApp.port_retries = 0
-c.ServerApp.base_url = '${BASE_URL}'
-c.ServerApp.PasswordIdentityProvider.hashed_password = '${PASSWORD}'
-c.ServerApp.allow_origin = '*'
-c.ServerApp.disable_check_xsrf = True
-c.ServerApp.open_browser = False
-c.WebPDFExporter.disable_sandbox = True
+# cat <<EOF > "${CONF_FILE}"
+# c = get_config()
 
-# --- UI & PERFORMANCE OPTIMIZATIONS ---
-# Disable backend extensions that cause extra polling or metadata scans.
-c.ServerApp.jpserver_extensions = {
-    'dask_labextension': False,
-    'jupyter_server_xarray_leaflet': False,
-    'jupyterlab_git': False,
-    'nbgitpuller': False,
-    'panel.io.jupyter_server_extension': False
-}
-EOF
+# # --- NETWORK & SECURITY ---
+# c.ServerApp.ip = '0.0.0.0'
+# c.ServerApp.port = ${PORT}
+# c.ServerApp.port_retries = 0
+# c.ServerApp.base_url = '${BASE_URL}'
+# c.ServerApp.PasswordIdentityProvider.hashed_password = '${PASSWORD}'
+# c.ServerApp.allow_origin = '*'
+# c.ServerApp.disable_check_xsrf = True
+# c.ServerApp.open_browser = False
+# c.WebPDFExporter.disable_sandbox = True
+
+# # --- UI & PERFORMANCE OPTIMIZATIONS ---
+# # Disable backend extensions that cause extra polling or metadata scans.
+# c.ServerApp.jpserver_extensions = {
+#     'dask_labextension': False,
+#     'jupyter_server_xarray_leaflet': False,
+#     'jupyterlab_git': False,
+#     'nbgitpuller': False,
+#     'panel.io.jupyter_server_extension': False
+# }
+# EOF
 
 # -------------------------------------------------------------------------
 # 3. LAUNCH JUPYTERLAB USING THE CONFIG FILE
@@ -101,5 +105,5 @@ EOF
 # so Slurm/OOD signals (TERM, INT) are delivered cleanly and jobs exit
 # promptly when cancelled.
 # -------------------------------------------------------------------------
-echo "INFO: Launching JupyterLab with config file: ${CONF_FILE}"
-exec jupyter lab --config "${CONF_FILE}"
+# echo "INFO: Launching JupyterLab with config file: ${CONF_FILE}"
+# exec jupyter lab --config "${CONF_FILE}"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -134,6 +134,9 @@ log "Using persistent workdir: ${WORKDIR_USER}"
 
 # ----------------------------------------------------------------------------
 # Jupyterlab emphemeral system configs:
+# Create the temporary config files that will be bind-mounted into the container. These
+mkdir -p "${WORKDIR_JOB}/config"
+
 # Write these to the ephemeral job storage, then bind them into the image.
 HOST_PAGE_CONFIG="${WORKDIR_JOB}/config/page_config.json"
 HOST_SERVER_CONFIG="${WORKDIR_JOB}/config/jupyter_server_config.py"
@@ -239,9 +242,27 @@ export SING_BINDS="${SING_BINDS} -B ${WORKDIR_JOB}/tmp:/tmp"
 
 # Inject our configs directly into Jupyter's system path inside the container.
 # This ensures they take precedence over any user configs and that we have a clean slate for our new scratch-based setup.
-export SING_BINDS="$SING_BINDS -B ${HOST_PAGE_CONFIG}:/etc/jupyter/labconfig/page_config.json"
-export SING_BINDS="$SING_BINDS -B ${HOST_SERVER_CONFIG}:/etc/jupyter/jupyter_server_config.py"
+# We will bind here after rebuilding the image with the new config paths, but keeping these here for reference:
+# export SING_BINDS="$SING_BINDS -B ${HOST_PAGE_CONFIG}:/etc/jupyter/labconfig/page_config.json"
+# export SING_BINDS="$SING_BINDS -B ${HOST_SERVER_CONFIG}:/etc/jupyter/jupyter_server_config.py"
 
+# ----------------------------------------------------------------------------
+# Bind ephemeral Jupyter configs to /srv/conda/envs/notebook/etc/jupyter/
+#
+# Precedence order: ~/.jupyter (cleaned above) → /srv/conda/.../etc/jupyter ← (we bind here) → /etc/jupyter
+#
+# WHY NOT /etc/jupyter/:
+# - /srv/conda/.../etc/jupyter/ ALREADY HAS CONFIGS enabling extensions (dask, git, etc.)
+# - Jupyter checks /srv/conda path BEFORE /etc/jupyter in search order
+# - Binding to /etc/jupyter would be IGNORED - the /srv/conda configs would win
+# - Bind to /srv/conda path to override the existing extension-enabling configs there
+#
+# CURRENT STATE: Users' ~/.jupyter configs override /srv/conda (causing performance issues)
+# AFTER THIS PR: Home cleaned → our disabled-extension configs in /srv/conda take effect
+# Future: Rebuild image with optimized configs baked into /srv/conda path directly
+# ----------------------------------------------------------------------------
+export SING_BINDS="$SING_BINDS -B ${HOST_PAGE_CONFIG}:/srv/conda/envs/notebook/etc/jupyter/labconfig/page_config.json"
+export SING_BINDS="$SING_BINDS -B ${HOST_SERVER_CONFIG}:/srv/conda/envs/notebook/etc/jupyter/jupyter_server_config.py"
 log "SING_BINDS=${SING_BINDS}"
 
 # JOBROOT is set by the OOD app; it points at the app's job directory

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -185,7 +185,9 @@ c.ServerApp.jpserver_extensions = {
     'jupyter_server_xarray_leaflet': False,
     'jupyterlab_git': False,
     'nbgitpuller': False,
-    'panel.io.jupyter_server_extension': False
+    'panel.io.jupyter_server_extension': False,
+    'jupyterlab_code_formatter': False,
+    'nbdime': False
 }
 EOF
 # ----

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -17,6 +17,20 @@ log "Starting main script"
 cd "${HOME}"
 
 # ---------------------------------------------------------------------------
+# Cleanup Jupyter configs from home directory so they don't conflict with system level configs
+# If these files exist, they can override the system-level JupyterLab configs we set up in the container,
+# because JupyterLab looks for config files in the user's home directory first. Removing them ensures that
+# the container's configs take precedence and that we have a clean slate for our new scratch-based
+# Remove legacy settings so they don't override our new system-level configs
+LEGACY_PAGE_CONFIG="${HOME}/.jupyter/labconfig/page_config.json"
+if [[ -f "${LEGACY_PAGE_CONFIG}" ]]; then
+    log "INFO: Cleaning up legacy Jupyter config from Home directory..."
+    rm -f "${LEGACY_PAGE_CONFIG}"
+    rmdir "${HOME}/.jupyter/labconfig" 2>/dev/null || true
+fi
+
+
+# ---------------------------------------------------------------------------
 # Container image selection
 #
 # - IMAGE_FILE is provided by the OOD app context (ERB: <%= context.imagefile %>).
@@ -118,6 +132,39 @@ mkdir -m 700 -p "${WORKDIR_USER}"/{runtime,cache,workspaces}
 log "Using job workdir: ${WORKDIR_JOB}"
 log "Using persistent workdir: ${WORKDIR_USER}"
 
+# ----------------------------------------------------------------------------
+# Jupyterlab emphemeral system configs:
+# Write these to the ephemeral job storage, then bind them into the image.
+HOST_PAGE_CONFIG="${WORKDIR_JOB}/config/page_config.json"
+HOST_SERVER_CONFIG="${WORKDIR_JOB}/config/jupyter_server_config.py"
+
+cat > "${HOST_PAGE_CONFIG}" <<'EOF'
+{
+  "disabledExtensions": {
+    "@jupyterlab/extensionmanager-extension": true, 
+    "@jupyterlab/git": true,
+    "@jupyterlab/github": true,
+    "@jupyterlab/google-drive": true,
+    "dask-labextension": true,
+    "jupyter-leaflet": true,
+    "jupyterlab-code-formatter": true,
+    "nbdime-jupyterlab": true
+  }
+}
+EOF
+
+cat > "${HOST_SERVER_CONFIG}" <<'EOF'
+c = get_config()
+c.ServerApp.jpserver_extensions = {
+    'dask_labextension': False,
+    'jupyter_server_xarray_leaflet': False,
+    'jupyterlab_git': False,
+    'nbgitpuller': False,
+    'panel.io.jupyter_server_extension': False
+}
+EOF
+# ----
+
 # JupyterLab workspaces: tab/layout metadata. Keeping this persistent lets
 # users reconnect to familiar layouts quickly.
 export APPTAINERENV_JUPYTERLAB_WORKSPACES_DIR="${WORKDIR_USER}/workspaces"
@@ -189,6 +236,11 @@ export SING_BINDS="${SING_BINDS} -B /scratch"
 
 # Bind the job-specific scratch tmp as /tmp inside the container.
 export SING_BINDS="${SING_BINDS} -B ${WORKDIR_JOB}/tmp:/tmp"
+
+# Inject our configs directly into Jupyter's system path inside the container.
+# This ensures they take precedence over any user configs and that we have a clean slate for our new scratch-based setup.
+export SING_BINDS="$SING_BINDS -B ${HOST_PAGE_CONFIG}:/etc/jupyter/labconfig/page_config.json"
+export SING_BINDS="$SING_BINDS -B ${HOST_SERVER_CONFIG}:/etc/jupyter/jupyter_server_config.py"
 
 log "SING_BINDS=${SING_BINDS}"
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -22,13 +22,33 @@ cd "${HOME}"
 # because JupyterLab looks for config files in the user's home directory first. Removing them ensures that
 # the container's configs take precedence and that we have a clean slate for our new scratch-based
 # Remove legacy settings so they don't override our new system-level configs
+# ---------------------------------------------------------------------------
+# Cleanup legacy Jupyter configs from home directory
+# These can override system-level configs if left behind from previous implementations
+# ---------------------------------------------------------------------------
+echo "Checking for legacy Jupyter configs..."
+
+# Remove old page_config.json
 LEGACY_PAGE_CONFIG="${HOME}/.jupyter/labconfig/page_config.json"
 if [[ -f "${LEGACY_PAGE_CONFIG}" ]]; then
-    log "INFO: Cleaning up legacy Jupyter config from Home directory..."
+    log "Removing legacy page_config.json from home directory"
     rm -f "${LEGACY_PAGE_CONFIG}"
     rmdir "${HOME}/.jupyter/labconfig" 2>/dev/null || true
 fi
 
+# Remove old jupyter_server_config.py from home directory root
+LEGACY_SERVER_CONFIG="${HOME}/jupyter_server_config.py"
+if [[ -f "${LEGACY_SERVER_CONFIG}" ]]; then
+    log "Removing legacy jupyter_server_config.py from home directory"
+    rm -f "${LEGACY_SERVER_CONFIG}"
+fi
+
+# Remove old jupyter_server_config.py from .jupyter directory
+LEGACY_SERVER_CONFIG_JUPYTER="${HOME}/.jupyter/jupyter_server_config.py"
+if [[ -f "${LEGACY_SERVER_CONFIG_JUPYTER}" ]]; then
+    log "Removing legacy jupyter_server_config.py from .jupyter directory"
+    rm -f "${LEGACY_SERVER_CONFIG_JUPYTER}"
+fi
 
 # ---------------------------------------------------------------------------
 # Container image selection
@@ -139,7 +159,9 @@ mkdir -p "${WORKDIR_JOB}/config"
 
 # Write these to the ephemeral job storage, then bind them into the image.
 HOST_PAGE_CONFIG="${WORKDIR_JOB}/config/page_config.json"
+log "Will write JupyterLab page_config.json to ${HOST_PAGE_CONFIG}"
 HOST_SERVER_CONFIG="${WORKDIR_JOB}/config/jupyter_server_config.py"
+log "Will write jupyter_server_config.py to ${HOST_SERVER_CONFIG}"
 
 cat > "${HOST_PAGE_CONFIG}" <<'EOF'
 {


### PR DESCRIPTION
## Overview

Addresses team feedback on possible configuration contamination within student. This PR moves our recent performance optimizations from the user's home directory to isolated, ephemeral configurations and binds inside the container. (An alternate approach would be to rebuild the image).

## Changes

- Ephemeral Configs (Bind Mounts): Stopped writing configuration files to ~/.jupyter. Configs are now generated in the temporary Slurm job directory and bind-mounted directly into the container's active Conda environment at /srv/conda/envs/notebook/etc/jupyter/. This completely isolates the environment and prevents cross-course contamination.

- Frontend & Backend Disablement: The ephemeral configs now explicitly disable both the frontend UI extensions (page_config.json) and the backend server extensions (jupyter_server_config.py) to fully neutralize heavy background processes from starting up.

- Legacy Cleanup: Added a pre-launch step in the wrapper script to automatically delete leftover page_config.json and jupyter_server_config.py files (and remove the empty labconfig folder) from users' ~/.jupyter directories. Since Jupyter prioritizes the home directory, this guarantees old settings won't override our new bind mounts.

- Proper Process Handling (exec): Returned to using the exec jupyter lab ... command in jupyter.script.sh. This ensures the Jupyter application properly replaces the bash shell as the primary PID, allowing it to correctly catch and handle clean shutdown signals from Slurm when the session ends.

## Notes

* **User Impact:** Change should be transparent to users. Workspaces still persist on Lustre, but their global configs stay clean.
* **Future Work:**
 * Bake these extension-blocking configs directly into the apptainer `.def` recipes to remove the need for runtime bind-mounting entirely.
 * Determine best approach for asynchronous job to restore image if missing from scratch on a regular basis.
 * Persistent scratch - given scratches faster I/O, using a persistent version would be a valuable addition to our Pcluster setup.

## Testing
&#9656; Verified Page config loads consistently under 4 min.
<details><summary>Verified Home Directory Clean up with script and scratch for a config files</summary>

```bash
[2026-02-18T19:47:30+00:00][template/before.sh.erb] original HOME=/home/prg038
[2026-02-18T19:47:30+00:00][template/before.sh.erb] user=prg038
[2026-02-18T19:47:30+00:00][template/before.sh.erb] new HOME=/shared/home/prg038
Script starting...
[2026-02-18T19:47:30+00:00][template/script.sh.erb] Starting main script
Checking for legacy Jupyter configs...
[2026-02-18T19:47:30+00:00][template/after.sh] Waiting for Jupyter Notebook server to open port 10464...
[2026-02-18T19:47:30+00:00][template/after.sh] Starting wait
[2026-02-18T19:47:30+00:00][template/script.sh.erb] Image is Pangeo Notebook, using Lustre path for container image.
[2026-02-18T19:47:30+00:00][template/script.sh.erb] Using container image: /scratch/apptainerImages/pangeo-notebook.sif
[2026-02-18T19:47:30+00:00][template/script.sh.erb] Using job workdir: /scratch/prg038/236
[2026-02-18T19:47:30+00:00][template/script.sh.erb] Using persistent workdir: /scratch/prg038/jupyter_persistent_state
[2026-02-18T19:47:30+00:00][template/script.sh.erb] Will write JupyterLab page_config.json to /scratch/prg038/236/config/page_config.json
[2026-02-18T19:47:30+00:00][template/script.sh.erb] Will write jupyter_server_config.py to /scratch/prg038/236/config/jupyter_server_config.py
[2026-02-18T19:47:30+00:00][template/script.sh.erb] SING_BINDS= -B /shared -B /scratch -B /scratch/prg038/236/tmp:/tmp -B /scratch/prg038/236/config/page_config.json:/srv/conda/envs/notebook/etc/jupyter/labconfig/page_config.json -B /scratch/prg038/236/config/jupyter_server_config.py:/srv/conda/envs/notebook/etc/jupyter/jupyter_server_config.py
[2026-02-18T19:47:30+00:00][template/script.sh.erb] JOBROOT=/shared/home/prg038/ondemand/data/sys/dashboard/batch_connect/dev/ood-jupyterlab-apptainer/epsci101/output/d1c5fdaf-14f6-4eef-af9d-2c343214365a
[2026-02-18T19:47:30+00:00][template/script.sh.erb] Starting to load Spack environment
[2026-02-18T19:47:57+00:00][template/script.sh.erb] Starting Jupyter
INFO: Launching Jupyter. System configs provided via Apptainer bind mounts.
```
</details>

<details><summary>Verified disabled extensions no longer loading or showing warning in jupyterlab</summary>

```bash
# Source: shared/home/prg038/ondemand/data/sys/dashboard/batch_connect/dev/ood-jupyterlab-apptainer/epsci101/output/d1c5fdaf-14f6-4eef-af9d-2c343214365a/output.log

# Extensions no longer loading: 
#     "@jupyterlab/extensionmanager-extension": true,
#     "@jupyterlab/git": true,
#     "@jupyterlab/github": true,
#     "@jupyterlab/google-drive": true,
#     "dask-labextension": true,
#     "jupyter-leaflet": true,
#     "jupyterlab-code-formatter": true,
#     "nbdime-jupyterlab": true

INFO: Launching Jupyter. System configs provided via Apptainer bind mounts.
[I 2026-02-18 19:48:00.644 ServerApp] jupyter_lsp | extension was successfully linked.
[I 2026-02-18 19:48:00.644 ServerApp] jupyter_resource_usage | extension was successfully linked.
[I 2026-02-18 19:48:00.648 ServerApp] jupyter_server_mathjax | extension was successfully linked.
[I 2026-02-18 19:48:00.648 ServerApp] jupyter_server_proxy | extension was successfully linked.
[I 2026-02-18 19:48:00.651 ServerApp] jupyter_server_terminals | extension was successfully linked.
[I 2026-02-18 19:48:00.655 ServerApp] jupyterlab | extension was successfully linked.
[I 2026-02-18 19:48:00.655 ServerApp] jupyterlab_myst | extension was successfully linked.
[I 2026-02-18 19:48:00.659 ServerApp] notebook | extension was successfully linked.
[I 2026-02-18 19:48:01.077 ServerApp] notebook_shim | extension was successfully linked.
[I 2026-02-18 19:48:02.230 ServerApp] nb_conda_kernels | enabled, 0 kernels found.
[I 2026-02-18 19:48:02.260 ServerApp] notebook_shim | extension was successfully loaded.
[I 2026-02-18 19:48:02.262 ServerApp] jupyter_lsp | extension was successfully loaded.
[I 2026-02-18 19:48:02.262 ServerApp] jupyter_resource_usage | extension was successfully loaded.
[I 2026-02-18 19:48:02.263 ServerApp] jupyter_server_mathjax | extension was successfully loaded.
[I 2026-02-18 19:48:02.304 ServerApp] jupyter_server_proxy | extension was successfully loaded.
[I 2026-02-18 19:48:02.305 ServerApp] jupyter_server_terminals | extension was successfully loaded.
[I 2026-02-18 19:48:02.317 LabApp] JupyterLab extension loaded from /srv/conda/envs/notebook/lib/python3.12/site-packages/jupyterlab
[I 2026-02-18 19:48:02.317 LabApp] JupyterLab application directory is /srv/conda/envs/notebook/share/jupyter/lab
[I 2026-02-18 19:48:02.318 LabApp] Extension Manager is 'pypi'.
[I 2026-02-18 19:48:02.392 ServerApp] jupyterlab | extension was successfully loaded.
[I 2026-02-18 19:48:02.401 ServerApp] jupyterlab_myst | extension was successfully loaded.
[I 2026-02-18 19:48:02.408 ServerApp] notebook | extension was successfully loaded.
[I 2026-02-18 19:48:02.409 ServerApp] Serving notebooks from local directory: /shared/home/prg038

```
</details>



## References

#### AWS Cron Jobs / Event Scheduling:
* [4 Ways to Run Cron Jobs in AWS](https://medium.com/better-programming/cron-job-patterns-in-aws-126fbf54a276#:~:text=Here%20are%20some%20options%20for%20running%20cron,Usually%20ship%20with%20their%20own%20job%20scheduler) (2019)
* [Medium: 28 Day Cron Jobs on EC2 Instances](https://medium.com/@hajarepoonam2002/day-28-cron-jobs-on-ec2-instances-c3eb3abc8eef#:~:text=Cron%20jobs%20in%20AWS%20give,%2C%20and%20maintenance%2Dfree%20scheduling) (2025)

